### PR TITLE
Stop replacing tag and repository in values.yaml

### DIFF
--- a/workspace/Makefile
+++ b/workspace/Makefile
@@ -38,17 +38,6 @@ release: clean
 	rm -rf ${NAME}*.tgz%
 
 tag:
-ifeq ($(OS),Darwin)
-	sed -i "" -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
-	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
-else ifeq ($(OS),Linux)
-	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
-	sed -i -e "s/repository: .*/repository: $(DOCKER_REPO)\/fairspace\/$(NAME)/" values.yaml
-	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
-else
-	echo "platfrom $(OS) not supported to release from"
-	exit -1
-endif
 	git add --all
 	git commit -m "release $(RELEASE_VERSION)" --allow-empty # if first release then no verion update is performed
 	git tag -fa v$(RELEASE_VERSION) -m "Release version $(RELEASE_VERSION)"

--- a/workspace/values.yaml
+++ b/workspace/values.yaml
@@ -6,31 +6,6 @@
 # Please note that if this is set, also set it for pluto in `pluto.workspace.name`
 nameOverride:
 
-replicaCount: 1
-
-image:
-  repository: nginx
-  tag: stable
-  pullPolicy: IfNotPresent
-
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #  cpu: 100m
-  #  memory: 128Mi
-  # requests:
-  #  cpu: 100m
-  #  memory: 128Mi
-
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
-
 # Hyperspace that this workspace is connected to
 # Please note that pluto also has to know about the
 # keycloak baseUrl and realm, see the pluto configuration


### PR DESCRIPTION
The replacement is not needed in this helm chart, as it is normally
used for matching the helm chart version with the docker image version.
As this chart does not have its own docker images, there is no need to
do the replacement. Moreover, it replaced tags for other images
(e.g. JupyterHub) as well, which caused errors.