### PR TITLE
Allow override Pluto OIDC client_id

### DIFF
--- a/charts/workspace/templates/secrets/client-secret.yaml
+++ b/charts/workspace/templates/secrets/client-secret.yaml
@@ -4,5 +4,5 @@ metadata:
   name: {{ .Release.Name }}-oauth-client
 type: Opaque
 data:
-  clientId: {{ (printf "%s-pluto" (include "workspace.name" .)) | b64enc | quote }}
+  clientId: {{ .Values.hyperspace.keycloak.clientId | default (printf "%s-pluto" (include "workspace.name" .)) | b64enc | quote }}
   clientSecret: {{ .Values.hyperspace.keycloak.clientSecret | default uuidv4 | b64enc | quote }}


### PR DESCRIPTION
Can be used for making multiple Fairspace deployments share a Keycloak
server.