### PR TITLE
Access webdav storage on specific storage ingress

### DIFF
--- a/charts/workspace/templates/_helpers.tpl
+++ b/charts/workspace/templates/_helpers.tpl
@@ -102,7 +102,7 @@ Scheme to access workspace components (http or https)
 
 {{/* Storage external hostname */}}
 {{- define "storage.hostname" -}}
-{{- printf "%s" .Values.workspace.ingress.domain -}}
+{{- printf "storage.%s" .Values.workspace.ingress.domain -}}
 {{- end -}}
 
 {{- define "workspace.url" -}}

--- a/charts/workspace/templates/ingress/storage-ingress.yaml
+++ b/charts/workspace/templates/ingress/storage-ingress.yaml
@@ -24,7 +24,7 @@ spec:
     - host: {{ template "storage.hostname" $ }}
       http:
         paths:
-          - path: /
+          - path: /(.*)
             backend:
               serviceName: {{ .Release.Name }}-pluto
               servicePort: 80

--- a/charts/workspace/values.yaml
+++ b/charts/workspace/values.yaml
@@ -46,7 +46,7 @@ workspace:
           storage:
             kubernetes.io/ingress.class: nginx
             nginx.ingress.kubernetes.io/proxy-body-size: 10g
-            nginx.ingress.kubernetes.io/rewrite-target: /zuul
+            nginx.ingress.kubernetes.io/rewrite-target: /zuul/$1
           jupyter:
             kubernetes.io/ingress.class: nginx
             nginx.ingress.kubernetes.io/proxy-body-size: 10g


### PR DESCRIPTION
The storage ingress has specific properties on post body size
as well as bypasses the pluto spring servlet for performance.
For that reason it is important to use the storage ingress
for anything related to storage.

Fixes VRE-598 and VRE-585