### PR TITLE
VRE-625 Disable support for Range headers

### DIFF
--- a/projects/saturn/src/main/java/io/fairspace/saturn/vfs/SafeFileSystem.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/vfs/SafeFileSystem.java
@@ -84,10 +84,10 @@ public class SafeFileSystem implements VirtualFileSystem {
     }
 
     @Override
-    public void read(String path, long offset, long maxLength, OutputStream out) throws IOException {
+    public void read(String path, OutputStream out) throws IOException {
         var normalizedPath = normalizePath(path);
         safely(() -> {
-            unsafe.read(normalizedPath, offset, maxLength, out);
+            unsafe.read(normalizedPath, out);
             return null;
         });
     }

--- a/projects/saturn/src/main/java/io/fairspace/saturn/vfs/VirtualFileSystem.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/vfs/VirtualFileSystem.java
@@ -31,11 +31,7 @@ public interface VirtualFileSystem extends Closeable {
 
     void modify(String path, InputStream in) throws IOException;
 
-    void read(String path, long offset, long maxLength, OutputStream out) throws IOException;
-
-    default void read(String path, OutputStream out) throws IOException {
-        read(path, 0, Long.MAX_VALUE, out);
-    }
+    void read(String path, OutputStream out) throws IOException;
 
     void copy(String from, String to) throws IOException;
 

--- a/projects/saturn/src/main/java/io/fairspace/saturn/vfs/managed/BlobStore.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/vfs/managed/BlobStore.java
@@ -7,5 +7,6 @@ import java.io.OutputStream;
 public interface BlobStore {
     String write(InputStream in) throws IOException;
 
-    void read(String id, long offset, long maxLength, OutputStream out) throws IOException;
+    void read(String id, OutputStream out) throws IOException;
+
 }

--- a/projects/saturn/src/main/java/io/fairspace/saturn/vfs/managed/LocalBlobStore.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/vfs/managed/LocalBlobStore.java
@@ -15,13 +15,13 @@ public class LocalBlobStore implements BlobStore {
 
     @Override
     public String write(InputStream in) throws IOException {
-        if (!dir.exists() && !dir.mkdirs()) {
+        if(!dir.exists() && !dir.mkdirs()) {
             throw new IOException("Cannot initialize the local blob store");
         }
         var id = randomUUID().toString();
         var dest = new File(dir, id);
         try (var out = new BufferedOutputStream(new FileOutputStream(dest))) {
-            copyLarge(in, out);
+             copyLarge(in, out);
         } catch (IOException e) {
             dest.delete();
             throw e;
@@ -30,10 +30,10 @@ public class LocalBlobStore implements BlobStore {
     }
 
     @Override
-    public void read(String id, long offset, long maxLength, OutputStream out) throws IOException {
+    public void read(String id, OutputStream out) throws IOException {
         var src = new File(dir, id);
-        try (var in = new BufferedInputStream(new FileInputStream(src))) {
-            copyLarge(in, out, offset, maxLength);
+        try(var in = new BufferedInputStream(new FileInputStream(src))) {
+            copyLarge(in, out);
         }
     }
 }

--- a/projects/saturn/src/main/java/io/fairspace/saturn/vfs/managed/ManagedFileSystem.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/vfs/managed/ManagedFileSystem.java
@@ -118,11 +118,11 @@ public class ManagedFileSystem implements VirtualFileSystem {
     }
 
     @Override
-    public void read(String path, long offset, long maxLength, OutputStream out) throws IOException {
+    public void read(String path, OutputStream out) throws IOException {
         var processor = new QuerySolutionProcessor<>(row -> row.getLiteral("blobId").getString());
         rdf.querySelect(storedQuery("fs_get_blobid", path), processor);
         var blobId = processor.getSingle().orElseThrow(() -> new FileNotFoundException(path));
-        store.read(blobId, offset, maxLength, out);
+        store.read(blobId, out);
     }
 
     @Override

--- a/projects/saturn/src/main/java/io/fairspace/saturn/webdav/MiltonWebDAVServlet.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/webdav/MiltonWebDAVServlet.java
@@ -3,13 +3,24 @@ package io.fairspace.saturn.webdav;
 
 import io.fairspace.saturn.vfs.VirtualFileSystem;
 import io.milton.config.HttpManagerBuilder;
-import io.milton.http.HttpManager;
+import io.milton.http.*;
+import io.milton.http.exceptions.BadRequestException;
+import io.milton.http.exceptions.NotAuthorizedException;
+import io.milton.http.exceptions.NotFoundException;
+import io.milton.http.http11.DefaultHttp11ResponseHandler;
+import io.milton.http.http11.Http11ResponseHandler;
+import io.milton.http.http11.PartialGetHelper;
+import io.milton.resource.GetableResource;
+import io.milton.resource.Resource;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
 
 import static io.milton.servlet.MiltonServlet.clearThreadlocals;
 import static io.milton.servlet.MiltonServlet.setThreadlocals;
@@ -43,8 +54,28 @@ public class MiltonWebDAVServlet extends HttpServlet {
         return new HttpManagerBuilder() {{
             setResourceFactory(new VfsBackedMiltonResourceFactory(pathPrefix, fs));
             setMultiNamespaceCustomPropertySourceEnabled(true);
-            setAuthenticationHandlers(singletonList(new SaturnAuthenticationHandler()));
+            setAuthenticationService(new AuthenticationService(singletonList(new SaturnAuthenticationHandler())));
             setValueWriters(new NullSafeValueWriters());
+
+            setHttp11ResponseHandler(new DefaultHttp11ResponseHandler(getAuthenticationService(), geteTagGenerator(), getContentGenerator()) {
+                // Doesn't send Accept-Ranges header
+                @Override
+                protected void setRespondCommonHeaders(Response response, Resource resource, Response.Status status, Auth auth) {
+                    response.setStatus(status);
+                    response.setDateHeader(new Date());
+                    var etag = generateEtag(resource);
+                    if (etag != null) {
+                        response.setEtag(etag);
+                    }
+                }
+            });
+            setPartialGetHelper(new PartialGetHelper() {
+                @Override
+                public void sendPartialContent(GetableResource resource, Request request, Response response, List<Range> ranges, Map<String, String> params, Http11ResponseHandler responseHandler) throws NotAuthorizedException, BadRequestException, IOException, NotFoundException {
+                    // According to HTTP/1.1 standard, a server MAY ignore the Range header
+                    responseHandler.respondContent(resource, response, request, params);
+                }
+            });
         }}.buildHttpManager();
     }
 }

--- a/projects/saturn/src/main/java/io/fairspace/saturn/webdav/VfsBackedMiltonFileResource.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/webdav/VfsBackedMiltonFileResource.java
@@ -18,7 +18,6 @@ import java.util.Map;
 
 import static io.milton.common.ContentTypeUtils.findAcceptableContentType;
 import static io.milton.common.ContentTypeUtils.findContentTypes;
-import static java.util.Optional.ofNullable;
 
 public class VfsBackedMiltonFileResource extends VfsBackedMiltonResource implements GetableResource, ReplaceableResource {
     public VfsBackedMiltonFileResource(VirtualFileSystem fs, FileInfo info) {
@@ -32,9 +31,7 @@ public class VfsBackedMiltonFileResource extends VfsBackedMiltonResource impleme
 
     @Override
     public void sendContent(OutputStream out, Range range, Map<String, String> params, String contentType) throws IOException, NotAuthorizedException, BadRequestException, NotFoundException {
-        var start = ofNullable(range).map(Range::getStart).orElse(0L);
-        var length = ofNullable(range).map(Range::getFinish).map(finish -> finish - start + 1).orElse(Long.MAX_VALUE);
-        fs.read(info.getPath(), start, length,  out);
+        fs.read(info.getPath(), out);
     }
 
     @Override

--- a/projects/saturn/src/test/java/io/fairspace/saturn/vfs/managed/LocalBlobStoreTest.java
+++ b/projects/saturn/src/test/java/io/fairspace/saturn/vfs/managed/LocalBlobStoreTest.java
@@ -1,6 +1,5 @@
 package io.fairspace.saturn.vfs.managed;
 
-import org.apache.commons.io.input.BrokenInputStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -17,10 +16,11 @@ import static org.junit.Assert.*;
 public class LocalBlobStoreTest {
     private final File dir = new File(getTempDirectory(), randomUUID().toString());
     private BlobStore blobStore;
-    private byte[] contents = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    private byte[] contents1 = new byte[]{0, 1, 2, 3};
+    private byte[] contents2 = new byte[]{4, 5, 6, 7, 8, 9};
 
     @Before
-    public void before() throws IOException {
+    public void before() {
         blobStore = new LocalBlobStore(dir);
     }
 
@@ -30,49 +30,19 @@ public class LocalBlobStoreTest {
     }
 
     @Test
-    public void testReadFully() throws IOException {
-        testReadRange(0, Long.MAX_VALUE, contents);
-    }
-
-    @Test
-    public void testReadExactSize() throws IOException {
-        testReadRange(0, contents.length, contents);
-    }
-
-    @Test
-    public void testReadSubRange() throws IOException {
-        testReadRange(2, 3, new byte[] {2, 3, 4});
-    }
-
-    @Test
-    public void testReadEmptyRange() throws IOException {
-        testReadRange(2, 0, new byte[0]);
-    }
-
-    @Test
-    public void testReadTail() throws IOException {
-        testReadRange(7, Long.MAX_VALUE, new byte[] {7, 8, 9});
-    }
-
-    @Test
-    public void testAfterEnd() throws IOException {
-        testReadRange(contents.length, 0, new byte[0]);
-    }
-
-    @Test
-    public void filesShouldBeDeletedInCaseOfErrors() {
-        try {
-            blobStore.write(new BrokenInputStream());
-        } catch (IOException ignore) {
-        }
-
-        assertEquals(0, dir.list().length);
-    }
-
-    private void testReadRange(long offset, long length, byte[] expected) throws IOException {
-        var id = blobStore.write(new ByteArrayInputStream(contents));
+    public void shouldReadExactlyWhatWasWritten() throws IOException {
+        var id = blobStore.write(new ByteArrayInputStream(contents1));
+        assertNotNull(id);
         var out = new ByteArrayOutputStream();
-        blobStore.read(id, offset, length, out);
-        assertArrayEquals(expected, out.toByteArray());
+        blobStore.read(id, out);
+        assertArrayEquals(contents1, out.toByteArray());
+    }
+
+
+    @Test
+    public void shouldGenerateUniqueIds() throws IOException {
+        var id1 = blobStore.write(new ByteArrayInputStream(contents1));
+        var id2 = blobStore.write(new ByteArrayInputStream(contents2));
+        assertNotEquals(id1, id2);
     }
 }

--- a/projects/saturn/src/test/java/io/fairspace/saturn/vfs/managed/MemoryBlobStore.java
+++ b/projects/saturn/src/test/java/io/fairspace/saturn/vfs/managed/MemoryBlobStore.java
@@ -21,7 +21,7 @@ public class MemoryBlobStore implements BlobStore {
     }
 
     @Override
-    public void read(String id, long offset, long maxLength, OutputStream out) throws IOException {
-        IOUtils.copy(new ByteArrayInputStream(memo.get(id), (int) offset, (int) Math.min(maxLength, Integer.MAX_VALUE)), out);
+    public void read(String id, OutputStream out) throws IOException {
+        IOUtils.copy(new ByteArrayInputStream(memo.get(id)), out);
     }
 }


### PR DESCRIPTION
As Milton's support for Range headers appeared to be buggy, I decided to disable this feature altogether.
Our WebDAV should never send Accept-Ranges headers and will ignore Range headers in GET requests  (as allowed by the HTTP standard).
I also removed support for ranges from VirtualFileSystem and BlobStore and their implementation