### PR TITLE
URL as the single source of truth for opened paths and collections

### DIFF
--- a/projects/mercury/src/actions/actionTypes.js
+++ b/projects/mercury/src/actions/actionTypes.js
@@ -14,9 +14,7 @@ export const CLIPBOARD_PASTE_FULFILLED              = 'CLIPBOARD_PASTE_FULFILLED
 export const CLIPBOARD_PASTE_REJECTED               = 'CLIPBOARD_PASTE_REJECTED';
 
 // Collection browser
-export const OPEN_COLLECTION                        = 'OPEN_COLLECTION';
 export const SELECT_COLLECTION                      = 'SELECT_COLLECTION';
-export const OPEN_PATH                              = 'OPEN_PATH';
 export const SELECT_PATH                            = 'SELECT_PATH';
 export const SET_SELECTED_PATHS                     = 'SET_SELECTED_PATHS';
 export const DESELECT_ALL_PATHS                     = 'DESELECT_ALL_PATHS';

--- a/projects/mercury/src/actions/collectionBrowserActions.js
+++ b/projects/mercury/src/actions/collectionBrowserActions.js
@@ -1,18 +1,8 @@
 import * as actionTypes from "./actionTypes";
 
-export const openCollection = collectionId => ({
-    type: actionTypes.OPEN_COLLECTION,
-    collectionId
-});
-
-export const selectCollection = collectionId => ({
+export const selectCollection = location => ({
     type: actionTypes.SELECT_COLLECTION,
-    collectionId
-});
-
-export const openPath = path => ({
-    type: actionTypes.OPEN_PATH,
-    path
+    location
 });
 
 export const selectPath = path => ({

--- a/projects/mercury/src/components/collections/CollectionBrowser.js
+++ b/projects/mercury/src/components/collections/CollectionBrowser.js
@@ -30,9 +30,9 @@ class CollectionBrowser extends React.Component {
     }
 
     handleCollectionClick = (collection) => {
-        const {selectedCollectionIRI, selectCollection} = this.props;
-        if (selectedCollectionIRI !== collection.iri) {
-            selectCollection(collection.iri);
+        const {selectedCollectionLocation, selectCollection} = this.props;
+        if (selectedCollectionLocation !== collection.location) {
+            selectCollection(collection.location);
         }
     }
 
@@ -65,7 +65,7 @@ class CollectionBrowser extends React.Component {
             <>
                 <CollectionList
                     collections={this.props.collections}
-                    selectedCollectionIRI={this.props.selectedCollectionIRI}
+                    selectedCollectionLocation={this.props.selectedCollectionLocation}
                     onCollectionClick={this.handleCollectionClick}
                     onCollectionDoubleClick={this.handleCollectionDoubleClick}
                 />
@@ -111,7 +111,7 @@ const mapStateToProps = (state) => ({
     error: state.cache.collections.error || state.account.user.error || state.cache.users.error,
     collections: state.cache.collections.data,
     users: state.cache.users.data,
-    selectedCollectionIRI: state.collectionBrowser.selectedCollectionIRI,
+    selectedCollectionLocation: state.collectionBrowser.selectedCollectionLocation,
     addingCollection: state.collectionBrowser.addingCollection,
     deletingCollection: state.collectionBrowser.deletingCollection
 });

--- a/projects/mercury/src/components/collections/CollectionList.js
+++ b/projects/mercury/src/components/collections/CollectionList.js
@@ -10,7 +10,7 @@ import getDisplayName from "../../utils/userUtils";
 
 const collectionList = (props) => {
     const {
-        collections, selectedCollectionIRI,
+        collections, selectedCollectionLocation,
         onCollectionClick, onCollectionDoubleClick, classes
     } = props;
 
@@ -30,7 +30,7 @@ const collectionList = (props) => {
                 </TableHead>
                 <TableBody>
                     {collections.map((collection) => {
-                        const selected = selectedCollectionIRI && (collection.iri === selectedCollectionIRI);
+                        const selected = selectedCollectionLocation && (collection.location === selectedCollectionLocation);
 
                         return (
                             <TableRow

--- a/projects/mercury/src/components/file/FileBrowser.js
+++ b/projects/mercury/src/components/file/FileBrowser.js
@@ -58,7 +58,6 @@ class FileBrowser extends React.Component {
 
     openDir(path) {
         this.props.history.push(`/collections${path}`);
-        this.props.openPath(path);
     }
 
     downloadFile(path) {

--- a/projects/mercury/src/components/file/FilesPage.test.js
+++ b/projects/mercury/src/components/file/FilesPage.test.js
@@ -21,6 +21,7 @@ describe('FilesPage', () => {
         it('updates url after collection location has changed', () => {
             const history = [];
             const wrapper = shallow(<FilesPage
+                fetchFilesIfNeeded={() => {}}
                 openedPath={openedPath}
                 openedCollection={openedCollection}
                 history={history}
@@ -36,7 +37,8 @@ describe('FilesPage', () => {
         it('can handle an empty openedPath', () => {
             const history = [];
             const wrapper = shallow(<FilesPage
-                openedPath={'/location1'}
+                fetchFilesIfNeeded={() => {}}
+                openedPath="/location1"
                 openedCollection={openedCollection}
                 history={history}
                 selectCollection={selectCollection}

--- a/projects/mercury/src/reducers/collectionBrowserReducers.js
+++ b/projects/mercury/src/reducers/collectionBrowserReducers.js
@@ -1,10 +1,8 @@
 import * as actionTypes from "../actions/actionTypes";
 
 const defaultState = {
-    selectedCollectionIRI: null,
+    selectedCollectionLocation: null,
     selectedPaths: [],
-    openedCollectionId: null,
-    openedPath: null,
     addingCollection: false,
     deletingCollection: false
 };
@@ -19,9 +17,8 @@ const collectionBrowser = (state = defaultState, action) => {
         case actionTypes.SELECT_COLLECTION:
             return {
                 ...state,
-                selectedCollectionIRI: action.collectionId,
+                selectedCollectionLocation: action.location,
                 selectedPaths: [],
-                openedPath: null
             };
         case actionTypes.SELECT_PATH:
             return {
@@ -49,7 +46,7 @@ const collectionBrowser = (state = defaultState, action) => {
             return {
                 ...state,
                 deletingCollection: false,
-                selectedCollectionIRI: state.selectedCollectionIRI === action.collectionId ? null : state.selectedCollectionIRI
+                selectedCollectionLocation: state.selectedCollectionLocation === action.collectionId ? null : state.selectedCollectionLocation
             };
         case actionTypes.DELETE_COLLECTION_REJECTED:
         case actionTypes.DELETE_COLLECTION_INVALIDATE:
@@ -75,12 +72,6 @@ const collectionBrowser = (state = defaultState, action) => {
             return {
                 ...state,
                 addingCollection: false
-            };
-        case actionTypes.OPEN_PATH:
-            return {
-                ...state,
-                openedPath: action.path,
-                selectedPaths: []
             };
         default:
             return state;

--- a/projects/mercury/src/reducers/collectionBrowserReducers.test.js
+++ b/projects/mercury/src/reducers/collectionBrowserReducers.test.js
@@ -10,16 +10,14 @@ describe('Collection browser reducers', () => {
             reducer(
                 undefined, {
                     type: actionTypes.SELECT_COLLECTION,
-                    collectionId: 'some-kind-of-id'
+                    location: 'col1'
                 }
             )
         ).toEqual({
             selectedPaths: [],
-            openedCollectionId: null,
-            openedPath: null,
             addingCollection: false,
             deletingCollection: false,
-            selectedCollectionIRI: 'some-kind-of-id'
+            selectedCollectionLocation: 'col1'
         });
     });
 
@@ -33,11 +31,9 @@ describe('Collection browser reducers', () => {
             )
         ).toEqual({
             selectedPaths: ['/some_collection/dir1'],
-            openedCollectionId: null,
-            openedPath: null,
             addingCollection: false,
             deletingCollection: false,
-            selectedCollectionIRI: null
+            selectedCollectionLocation: null
         });
     });
 
@@ -62,9 +58,7 @@ describe('Collection browser reducers', () => {
         ).toEqual({
             addingCollection: false,
             deletingCollection: false,
-            openedCollectionId: null,
-            openedPath: null,
-            selectedCollectionIRI: null,
+            selectedCollectionLocation: null,
             selectedPaths: []
         });
     });
@@ -73,9 +67,7 @@ describe('Collection browser reducers', () => {
         const state = {
             addingCollection: false,
             deletingCollection: false,
-            openedCollectionId: null,
-            openedPath: null,
-            selectedCollectionIRI: null,
+            selectedCollectionLocation: null,
             selectedPaths: ['/some_collection/dir1', '/some_collection/dir2', '/some_collection/dir3', '/some_collection/dir4']
         };
 
@@ -87,9 +79,7 @@ describe('Collection browser reducers', () => {
         ).toEqual({
             addingCollection: false,
             deletingCollection: false,
-            openedCollectionId: null,
-            openedPath: null,
-            selectedCollectionIRI: null,
+            selectedCollectionLocation: null,
             selectedPaths: ['/some_collection/dir2', '/some_collection/dir3', '/some_collection/dir4']
         });
     });
@@ -98,9 +88,7 @@ describe('Collection browser reducers', () => {
         const state = {
             addingCollection: false,
             deletingCollection: false,
-            openedCollectionId: null,
-            openedPath: null,
-            selectedCollectionIRI: null,
+            selectedCollectionLocation: null,
             selectedPaths: ['/some_collection/dir1', '/some_collection/dir2', '/some_collection/dir3', '/some_collection/dir4']
         };
 
@@ -114,9 +102,7 @@ describe('Collection browser reducers', () => {
         ).toEqual({
             addingCollection: false,
             deletingCollection: false,
-            openedCollectionId: null,
-            openedPath: null,
-            selectedCollectionIRI: null,
+            selectedCollectionLocation: null,
             selectedPaths: ['/some_collection/dir2', '/some_collection/dir3', '/some_collection/dir4']
         });
     });
@@ -125,9 +111,7 @@ describe('Collection browser reducers', () => {
         const state = {
             addingCollection: false,
             deletingCollection: true,
-            openedCollectionId: null,
-            openedPath: null,
-            selectedCollectionIRI: 'some-kind-of-id',
+            selectedCollectionLocation: 'some-kind-of-id',
             selectedPaths: []
         };
 
@@ -139,34 +123,7 @@ describe('Collection browser reducers', () => {
         ).toEqual({
             addingCollection: false,
             deletingCollection: false,
-            openedCollectionId: null,
-            openedPath: null,
-            selectedCollectionIRI: null,
-            selectedPaths: []
-        });
-    });
-
-    it('should return the opened path on open path action', () => {
-        const state = {
-            addingCollection: false,
-            deletingCollection: false,
-            openedCollectionId: null,
-            openedPath: null,
-            selectedCollectionIRI: null,
-            selectedPaths: []
-        };
-
-        expect(
-            reducer(state, {
-                type: actionTypes.OPEN_PATH,
-                path: 'a/given/path'
-            })
-        ).toEqual({
-            addingCollection: false,
-            deletingCollection: false,
-            openedCollectionId: null,
-            openedPath: 'a/given/path',
-            selectedCollectionIRI: null,
+            selectedCollectionLocation: null,
             selectedPaths: []
         });
     });
@@ -175,9 +132,7 @@ describe('Collection browser reducers', () => {
         const state = {
             addingCollection: false,
             deletingCollection: false,
-            openedCollectionId: null,
-            openedPath: null,
-            selectedCollectionIRI: null,
+            selectedCollectionLocation: null,
             selectedPaths: ['/some_collection/dir1', '/some_collection/dir2', '/some_collection/dir3', '/some_collection/dir4']
         };
 
@@ -185,9 +140,7 @@ describe('Collection browser reducers', () => {
             .toEqual({
                 addingCollection: false,
                 deletingCollection: false,
-                openedCollectionId: null,
-                openedPath: null,
-                selectedCollectionIRI: null,
+                selectedCollectionLocation: null,
                 selectedPaths: []
             });
     });
@@ -197,9 +150,7 @@ describe('Collection browser reducers', () => {
             .toEqual({
                 addingCollection: false,
                 deletingCollection: false,
-                openedCollectionId: null,
-                openedPath: null,
-                selectedCollectionIRI: null,
+                selectedCollectionLocation: null,
                 selectedPaths: []
             });
     });

--- a/projects/mercury/src/utils/fileUtils.js
+++ b/projects/mercury/src/utils/fileUtils.js
@@ -85,3 +85,10 @@ export function getDirectoryFromFullpath(path) {
 
     return cleanedPath.substring(firstSlashPosition);
 }
+
+export const getPathInfoFromParams = ({collection, path}) => (
+    {
+        collectionLocation: collection,
+        openedPath: `/${collection || ''}${path ? `/${path}` : ''}`
+    }
+);

--- a/projects/mercury/src/utils/fileUtils.test.js
+++ b/projects/mercury/src/utils/fileUtils.test.js
@@ -1,6 +1,7 @@
 import {
     addCounterToFilename, getFileName, getDirectoryFromFullpath,
-    getParentPath, generateUniqueFileName, getBaseNameAndExtension
+    getParentPath, generateUniqueFileName, getBaseNameAndExtension,
+    getPathInfoFromParams
 } from './fileUtils';
 
 describe('getBaseNameAndExtension', () => {
@@ -102,5 +103,22 @@ describe('addCounterToFilename', () => {
     it('Increments the correct counter if there is one already', () => {
         expect(addCounterToFilename('/some/path/file (123) (123).ext')).toEqual('/some/path/file (123) (124).ext');
         expect(addCounterToFilename('/some/path/file (123) (123)')).toEqual('/some/path/file (123) (124)');
+    });
+});
+
+describe('getPathInfoFromParams', () => {
+    expect(getPathInfoFromParams({collection: '', path: ''})).toEqual({
+        collectionLocation: '',
+        openedPath: '/'
+    });
+
+    expect(getPathInfoFromParams({collection: undefined, path: undefined})).toEqual({
+        collectionLocation: undefined,
+        openedPath: '/'
+    });
+
+    expect(getPathInfoFromParams({collection: 'collectionX', path: 'something/something'})).toEqual({
+        collectionLocation: 'collectionX',
+        openedPath: '/collectionX/something/something'
     });
 });


### PR DESCRIPTION
Changes:

* The source of opened collections and paths is only coming from URL now (Redux doesn't know about this)
* The selection of a collection is done through it's 'location' rather than it's IRI
    * The reason for this is to have a unified way to getting the selected/opened collection info, all through the llocation