### PR TITLE
Update keycloak configuration to enable datasteward role. 

### DIFF
--- a/charts/workspace/templates/config/configure-keycloak-job.yaml
+++ b/charts/workspace/templates/config/configure-keycloak-job.yaml
@@ -58,6 +58,16 @@ spec:
               secretKeyRef:
                 name: "{{ template "workspace.fullname" . }}-coordinator"
                 key: password
+          - name: DATASTEWARD_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: "{{ template "workspace.fullname" . }}-datasteward"
+                key: username
+          - name: DATASTEWARD_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "{{ template "workspace.fullname" . }}-datasteward"
+                key: password
           - name: CLIENT_SECRET
             valueFrom:
               secretKeyRef:

--- a/charts/workspace/templates/secrets/datasteward-secret.yaml
+++ b/charts/workspace/templates/secrets/datasteward-secret.yaml
@@ -1,0 +1,16 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ template "workspace.fullname" . }}-datasteward
+type: Opaque
+data:
+{{- if .Values.workspace.datasteward.username }}
+  username: {{ .Values.workspace.datasteward.username | b64enc | quote }}
+{{- else }}
+  username: {{ printf "datasteward-%s" (include "workspace.name" .) | b64enc | quote }}
+{{- end }}
+{{- if .Values.workspace.datasteward.password }}
+  password: {{ .Values.workspace.datasteward.password | b64enc | quote }}
+{{- else }}
+  password: {{ randAlphaNum 10 | b64enc | quote }}
+{{- end }}

--- a/charts/workspace/values.yaml
+++ b/charts/workspace/values.yaml
@@ -61,15 +61,20 @@ workspace:
                 dns01Provider: clouddns
 
     testuser:
-        password: fairspace123
+      username:
+      password: fairspace123
     coordinator:
-        password: fairspace123
+      username:
+      password: fairspace123
+    datasteward:
+      username:
+      password: fairspace123
 
     # Scripts for setting up keycloak for a workspace
     configurationScripts:
       keycloak:
         enabled: true
-        image: fairspace.azurecr.io/fairspace/keycloak-configuration:0.1.1
+        image: fairspace.azurecr.io/fairspace/keycloak-configuration:0.1.2
         pullPolicy: IfNotPresent
     enableExperimentalFeatures: false
 


### PR DESCRIPTION
Fixes VRE-393. This PR follows on the [PR for the keycloak-configuration scripts](https://github.com/fairspace/keycloak-configuration/pull/10) and should only be merged after that PR is merged and a new version of the keycloak configuration scripts have been released.