### PR TITLE
Add script to configure ES index with a default mapping.

### DIFF
--- a/charts/workspace/requirements.yaml
+++ b/charts/workspace/requirements.yaml
@@ -5,4 +5,4 @@ dependencies:
 - name: elasticsearch
   version: "1.21.2"
   repository: https://kubernetes-charts.storage.googleapis.com
-  condition: workspace.elasticsearch.enabled
+  condition: elasticsearch.install

--- a/charts/workspace/templates/_helpers.tpl
+++ b/charts/workspace/templates/_helpers.tpl
@@ -131,16 +131,16 @@ Scheme to access workspace components (http or https)
 {{- .Values.pluto.nameOverride | default (printf "%s-pluto" .Release.Name) -}}
 {{- end -}}
 
-{{- define "workspace.elasticsearch.restbaseurl" -}}
+{{- define "workspace.elasticsearch.resthost" -}}
 {{- if .Values.workspace.elasticsearch.host -}}
-{{- printf "http://%s" .Values.workspace.elasticsearch.host -}}
+{{- .Values.workspace.elasticsearch.host -}}
 {{- else -}}
-{{- printf "http://%s-elasticsearch-client.%s.svc.cluster.local" .Release.Name .Release.Namespace -}}
+{{- printf "%s-elasticsearch-client.%s.svc.cluster.local" .Release.Name .Release.Namespace -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "workspace.elasticsearch.resturl" -}}
-{{- template "workspace.elasticsearch.restbaseurl" . -}}:{{- int64 .Values.workspace.elasticsearch.restport -}}
+http://{{- template "workspace.elasticsearch.resthost" . -}}:{{- int64 .Values.workspace.elasticsearch.restport -}}
 {{- end -}}
 
 {{- define "workspace.elasticsearch.transporthost" -}}

--- a/charts/workspace/templates/config/configure-elastic-job.yaml
+++ b/charts/workspace/templates/config/configure-elastic-job.yaml
@@ -1,0 +1,62 @@
+{{- $scripts := .Values.workspace.configurationScripts.elasticsearch -}}
+{{- if $scripts.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{.Release.Name}}-elastic-configuration"
+  labels:
+    heritage: {{.Release.Service | quote }}
+    release: {{.Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+      name: "{{.Release.Name}}-elastic-configuration"
+      labels:
+        heritage: {{.Release.Service | quote }}
+        release: {{.Release.Name | quote }}
+        chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    spec:
+      restartPolicy: Never
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{ toYaml . | indent 8 }}
+      {{- end }}
+      initContainers:
+      - name: wait-for-elasticsearch
+        image: "{{ $scripts.initContainer.image }}"
+        imagePullPolicy: {{ $scripts.initContainer.pullPolicy }}
+        command:
+          - sh
+          - -c
+          - |
+            until printf "." && nc -z -w 2 {{ template "workspace.elasticsearch.resthost" . }} {{ .Values.workspace.elasticsearch.restport }}; do
+                sleep 2;
+            done;
+            echo 'ElasticSearch OK ✓'
+      containers:
+      - name: configure-elastic-job
+        image: "{{ $scripts.configurationContainer.image }}"
+        imagePullPolicy: {{ $scripts.configurationContainer.pullPolicy }}
+        volumeMounts:
+        - name: config-volume
+          mountPath: /opt/config
+        command:
+          - curl
+        args:
+          - "-X PUT"
+          - "-vv"
+          - "-H"
+          - "Content-Type: application/json"
+          - "-d"
+          - "@/opt/config/es-index-configuration.json"
+          - "{{ template "workspace.elasticsearch.resturl" . }}/{{ .Values.workspace.elasticsearch.indexName }}"
+      volumes:
+      - name: config-volume
+        configMap:
+          name: "{{.Release.Name}}-elastic-config-map"
+{{- end -}}

--- a/charts/workspace/templates/config/elastic-config-map.yaml
+++ b/charts/workspace/templates/config/elastic-config-map.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.workspace.configurationScripts.elasticsearch.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{.Release.Name}}-elastic-config-map"
+  labels:
+    heritage: {{.Release.Service | quote }}
+    release: {{.Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+data:
+  es-index-configuration.json: |-
+    {
+      "settings":{
+        "analysis":{
+          "analyzer":{
+            "ngram_analyzer":{
+              "type":"custom",
+              "tokenizer":"ngram_tokenizer",
+              "filter":[
+                "lowercase"
+              ]
+            }
+          },
+          "tokenizer":{
+            "ngram_tokenizer":{
+              "type":"ngram",
+              "min_gram":3,
+              "max_gram":3,
+              "token_chars":[
+                "letter",
+                "digit"
+              ]
+            }
+          }
+        }
+      },
+      "mappings":{
+        "iri":{
+          "properties":{
+            "filePath":{
+              "type":"text",
+              "analyzer":"ngram_analyzer"
+            }
+          }
+        }
+      }
+    }
+{{- end -}}

--- a/charts/workspace/templates/projects/saturn/configmap.yaml
+++ b/charts/workspace/templates/projects/saturn/configmap.yaml
@@ -23,7 +23,7 @@ data:
           clusterName: "elasticsearch"
           shards: 1
           replicas: 1
-          indexName: "fairspace"
+          indexName: "{{ .Values.workspace.elasticsearch.indexName }}"
     auth:
       enabled: true
       jwksUrl: {{ template "keycloak.baseUrl" . }}/auth/realms/{{ .Values.hyperspace.keycloak.realm }}/protocol/openid-connect/certs

--- a/charts/workspace/values.yaml
+++ b/charts/workspace/values.yaml
@@ -80,17 +80,29 @@ workspace:
       groups:
         user:
 
-    # Scripts for setting up keycloak for a workspace
+    # Scripts for setting up elasticsearch and keycloak for a workspace
     configurationScripts:
+      elasticsearch:
+        enabled: true
+        initContainer:
+          image: alpine:3.8
+          pullPolicy: IfNotPresent
+        configurationContainer:
+          image: appropriate/curl:latest
+          pullPolicy: IfNotPresent
       keycloak:
         enabled: true
         image: fairspace.azurecr.io/fairspace/keycloak-configuration:0.1.2
         pullPolicy: IfNotPresent
+
     enableExperimentalFeatures: false
+
     elasticsearch:
-        enabled: true
-        restport: 9200
-        transportport: 9300
+      enabled: true
+      host:
+      restport: 9200
+      transportport: 9300
+      indexName: fairspace
 
 # Generic settings for tracing
 tracing:
@@ -322,6 +334,9 @@ jupyterhub:
 # Specific settings for ElasticSearch
 #####################################################################
 elasticsearch:
+  # Whether to install ES in the cluster. If set to false
+  # you should provide an alternative elastic search host in workspace.elasticsearch.host
+  install: true
   persistence:
     enabled: true
     size: 20Gi


### PR DESCRIPTION
The configuration script is only being executed on installation. It requires the index not to be present yet, so it only works on new installations. The reason for this is that ES does not allow updating of mappings for existing fields. 

Fixes VRE-669