### PR TITLE
OIDC-Auth: OAuthAuthenticationToken serializable

### DIFF
--- a/projects/oidc-auth/oidc-auth-core/build.gradle
+++ b/projects/oidc-auth/oidc-auth-core/build.gradle
@@ -15,7 +15,6 @@ dependencies {
     implementation "org.springframework:spring-core:${springVersion}"
     implementation "org.springframework:spring-context:${springVersion}"
     implementation "org.springframework:spring-beans:${springVersion}"
-    implementation "org.apache.commons:commons-lang3:3.8.1"
 
     testCompile "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
     testCompile "org.junit.jupiter:junit-jupiter-params:${junitVersion}"

--- a/projects/oidc-auth/oidc-auth-core/src/main/java/io/fairspace/oidc_auth/model/OAuthAuthenticationToken.java
+++ b/projects/oidc-auth/oidc-auth-core/src/main/java/io/fairspace/oidc_auth/model/OAuthAuthenticationToken.java
@@ -8,14 +8,10 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.Serializable;
-import java.io.IOException;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import org.apache.commons.lang3.SerializationUtils;
 
 import static io.fairspace.oidc_auth.config.AuthConstants.AUTHORITIES_CLAIM;
 
@@ -26,6 +22,8 @@ import static io.fairspace.oidc_auth.config.AuthConstants.AUTHORITIES_CLAIM;
 @ToString(exclude = "claimsSet")
 @Slf4j
 public class OAuthAuthenticationToken implements Serializable {
+    private static final long serialVersionUID = 42L;
+
     public static final String USERNAME_CLAIM = "preferred_username";
     public static final String FULLNAME_CLAIM = "name";
     public static final String FIRSTNAME_CLAIM = "given_name";
@@ -86,11 +84,4 @@ public class OAuthAuthenticationToken implements Serializable {
         return list.stream().map(o -> o.toString()).collect(Collectors.toList());
     }
 
-    public byte[] convertToBytes(Object object) throws IOException {
-        return SerializationUtils.serialize(this);
-    }
-
-    public Object convertFromBytes(byte[] bytes) throws IOException, ClassNotFoundException {
-        return SerializationUtils.deserialize(bytes);
-    }
 }

--- a/projects/oidc-auth/oidc-auth-core/src/test/java/io/fairspace/oidc_auth/model/OAuthAuthenticationTokenTest.java
+++ b/projects/oidc-auth/oidc-auth-core/src/test/java/io/fairspace/oidc_auth/model/OAuthAuthenticationTokenTest.java
@@ -5,15 +5,28 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.util.SerializationUtils;
 
 public class OAuthAuthenticationTokenTest {
     @Test
-    void testTokenSerialization () throws ClassNotFoundException, IOException {
-        OAuthAuthenticationToken token1 = new OAuthAuthenticationToken("ACCESSTOKEN","REFRESHTOKEN");
-        assert(token1.equals(token1.convertFromBytes(token1.convertToBytes(token1))));
-        Map<String,Object> claimsSet = new HashMap();
+    void testTokenSerialization() throws ClassNotFoundException, IOException {
+        OAuthAuthenticationToken token = new OAuthAuthenticationToken("ACCESSTOKEN", "REFRESHTOKEN");
+        byte[] serialized = SerializationUtils.serialize(token);
+        OAuthAuthenticationToken deserialized = (OAuthAuthenticationToken) SerializationUtils.deserialize(serialized);
+
+        assert (token.equals(deserialized));
+    }
+
+    @Test
+    void testTokenSerializationWithMap() throws ClassNotFoundException, IOException {
+        Map<String, Object> claimsSet = new HashMap();
         claimsSet.put("CLAIM", "OBJECT");
-        OAuthAuthenticationToken token2 = new OAuthAuthenticationToken("foo",claimsSet);
-        assert(token2.equals(token2.convertFromBytes(token2.convertToBytes(token2))));
+        OAuthAuthenticationToken token = new OAuthAuthenticationToken("foo", claimsSet);
+
+        byte[] serialized = SerializationUtils.serialize(token);
+        OAuthAuthenticationToken deserialized = (OAuthAuthenticationToken) SerializationUtils.deserialize(serialized);
+
+        assert (token.equals(deserialized));
+
     }
 }


### PR DESCRIPTION
The class should be serializable so tokens can easily be stored in an
external store, such as Redis, by Pluto.