### PR TITLE
Do not check permissions for blank nodes

### DIFF
--- a/projects/saturn/src/main/java/io/fairspace/saturn/services/metadata/validation/PermissionCheckingValidator.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/services/metadata/validation/PermissionCheckingValidator.java
@@ -33,7 +33,9 @@ public class PermissionCheckingValidator implements MetadataRequestValidator {
         var resourcesToValidate = new HashSet<Resource>();
 
         model.listStatements().forEachRemaining(stmt -> {
-                    resourcesToValidate.add(stmt.getSubject());
+                    if (stmt.getSubject().isURIResource()) {
+                        resourcesToValidate.add(stmt.getSubject());
+                    }
 
                     if (stmt.getObject().isURIResource() &&
                             Stream.of(vocabularies)


### PR DESCRIPTION
As these blank nodes are not allowed as subject in another graph. Fixes VRE-701