### PR TITLE
Revert propagating metadata changes for every keystroke

### DIFF
--- a/projects/mercury/src/components/metadata/values/BaseInputValue.js
+++ b/projects/mercury/src/components/metadata/values/BaseInputValue.js
@@ -8,11 +8,17 @@ class BaseInputValue extends React.Component {
         this.state = {value: props.entry.value};
     }
 
+    componentDidUpdate(prevProps) {
+        if (this.props.entry.value !== prevProps.entry.value) {
+            this.reset();
+        }
+    }
+
     handleChange = (e) => {
         this.setState({value: e.target.value});
     }
 
-    handleSave = () => {
+    handleBlur = () => {
         const {onChange, transformValue} = this.props;
         onChange({value: transformValue(this.state.value)});
         this.reset();
@@ -33,7 +39,7 @@ class BaseInputValue extends React.Component {
                 multiline={property.multiLine}
                 value={this.state.value}
                 onChange={this.handleChange}
-                onBlur={this.handleSave}
+                onBlur={this.handleBlur}
                 margin="normal"
                 style={{...style, marginTop: 0, width: '100%'}}
             />

--- a/projects/mercury/src/components/metadata/values/DateTimeValue.js
+++ b/projects/mercury/src/components/metadata/values/DateTimeValue.js
@@ -8,11 +8,17 @@ class DateTimeValue extends React.Component {
         this.state = {value: props.entry.value || ''};
     }
 
+    componentDidUpdate(prevProps) {
+        if (this.props.entry.value !== prevProps.entry.value) {
+            this.reset();
+        }
+    }
+
     handleChange = (e) => {
         this.setState({value: e.target.value});
     }
 
-    handleSave = () => {
+    handleBlur = () => {
         this.props.onChange({value: this.delocalize(this.state.value)});
     }
 
@@ -31,8 +37,8 @@ class DateTimeValue extends React.Component {
                 multiline={false}
                 value={this.localize(this.state.value)}
                 type="datetime-local"
-                onChange={this.handleChange.bind}
-                onBlur={this.handleSave.bind}
+                onChange={this.handleChange}
+                onBlur={this.handleBlur}
                 margin="normal"
                 style={{...style, marginTop: 0, width: '100%'}}
             />

--- a/projects/mercury/src/components/metadata/values/ResourceValue.js
+++ b/projects/mercury/src/components/metadata/values/ResourceValue.js
@@ -8,11 +8,17 @@ class ResourceValue extends React.Component {
         this.state = {value: props.entry.id, oldValue: props.entry.id};
     }
 
+    componentDidUpdate(prevProps) {
+        if (this.props.entry.value !== prevProps.entry.value) {
+            this.reset();
+        }
+    }
+
     handleChange = (e) => {
         this.setState({value: e.target.value});
     }
 
-    handleSave = () => {
+    handleBlur = () => {
         try {
             this.props.onChange({id: new URL(this.state.value).toString()});
         } catch (e) {
@@ -31,7 +37,7 @@ class ResourceValue extends React.Component {
                 multiline={property.multiLine}
                 value={this.state.value}
                 onChange={this.handleChange}
-                onBlur={this.handleSave}
+                onBlur={this.handleBlur}
                 margin="normal"
                 style={{...style, marginTop: 0, width: '100%'}}
                 type="url"


### PR DESCRIPTION
This fixes the bug that the input field loses focus after one keystroke
and the bug that for lists of strings, a new string is added after every
character.