### PR TITLE
VRE-657 Don't update metadata if value is empty unless already had value

### DIFF
--- a/projects/mercury/src/components/metadata/values/BaseInputValue.js
+++ b/projects/mercury/src/components/metadata/values/BaseInputValue.js
@@ -10,7 +10,7 @@ class BaseInputValue extends React.Component {
 
     componentDidUpdate(prevProps) {
         if (this.props.entry.value !== prevProps.entry.value) {
-            this.reset();
+            this.updateState();
         }
     }
 
@@ -19,12 +19,17 @@ class BaseInputValue extends React.Component {
     }
 
     handleBlur = () => {
-        const {onChange, transformValue} = this.props;
-        onChange({value: transformValue(this.state.value)});
-        this.reset();
+        const {onChange, transformValue, entry: {value: oldValue}} = this.props;
+        const {value: newValue} = this.state;
+
+        // only if values don't match OR if the inputted value is empty AND already had value (removed existing)
+        if (newValue !== oldValue || (!newValue && oldValue)) {
+            onChange({value: transformValue(newValue)});
+            this.updateState();
+        }
     }
 
-    reset() {
+    updateState = () => {
         this.setState({value: this.props.entry.value});
     }
 


### PR DESCRIPTION
This is the fix for the bug reported by Jochem:

> One last issue is that every empty field is now automatically a string after selecting it. This causes updates with empty string fields e.g. "rdfs:label": "" and someone causes an error when selecting and unselecting an integer field (see attached screenshot).