### PR TITLE
Ensure that Saturn starts after ElasticSearch up

### DIFF
--- a/charts/workspace/templates/projects/saturn/deployment.yaml
+++ b/charts/workspace/templates/projects/saturn/deployment.yaml
@@ -27,6 +27,18 @@ spec:
 {{ toYaml .Values.podAnnotations.saturn | indent 8 }}
 {{- end }}
     spec:
+      initContainers:
+      - name: wait-for-elasticsearch
+        image: "{{ .Values.saturn.initContainer.image }}"
+        imagePullPolicy: {{ .Values.saturn.initContainer.pullPolicy }}
+        command:
+          - sh
+          - -c
+          - |
+            until printf "." && nc -z -w 2 "{{ template "workspace.elasticsearch.transporthost" . }}" "{{ .Values.workspace.elasticsearch.transportport }}"; do
+                sleep 2;
+            done;
+            echo 'ElasticSearch OK ✓'
       containers:
         - name: {{ template "saturn.fullname" . }}
           image: "{{ .Values.saturn.image.image }}:{{ .Values.saturn.image.tag }}"

--- a/charts/workspace/values.yaml
+++ b/charts/workspace/values.yaml
@@ -174,7 +174,9 @@ saturn:
     image: eu.gcr.io/fairspace-207108/saturn
     tag: RELEASEVERSION
     pullPolicy: IfNotPresent
-
+  initContainer:
+    image: alpine:3.9
+    pullPolicy: IfNotPresent
   service:
     name: saturn
     type: ClusterIP


### PR DESCRIPTION
If Saturn starts before ElasticSearch is ready, Saturn's ElasticSearch
connection won't be set up automatically, and Saturn will need to be
restarted manually.