### PR TITLE
Bugfix/vre 721 always use http for iris

### DIFF
--- a/projects/mercury/src/components/metadata/common/LinkedDataLink.js
+++ b/projects/mercury/src/components/metadata/common/LinkedDataLink.js
@@ -11,13 +11,18 @@ import * as PropTypes from "prop-types";
  * @constructor
  */
 const LinkedDataLink = ({uri, children}) => {
-    const {hostname, pathname, search, hash} = new URL(uri);
-    const uriIsSameOrigin = hostname === window.location.hostname;
+    try {
+        const {hostname, pathname, search, hash} = new URL(uri);
+        const uriIsSameOrigin = hostname === window.location.hostname;
 
-    return (uriIsSameOrigin
-        ? <Link to={{pathname, search, hash}}>{children}</Link>
-        : <a href={uri}>{children}</a>
-    );
+        return (uriIsSameOrigin
+            ? <Link to={{pathname, search, hash}}>{children}</Link>
+            : <a href={uri}>{children}</a>
+        );
+    } catch (e) {
+        console.warn("Invalid URL passed to LinkedDataLink component", uri);
+        return <a href={uri}>{children}</a>;
+    }
 };
 
 LinkedDataLink.propTypes = {

--- a/projects/mercury/src/components/metadata/common/LinkedDataLink.test.js
+++ b/projects/mercury/src/components/metadata/common/LinkedDataLink.test.js
@@ -42,9 +42,15 @@ describe('MetadataLink', () => {
         expect(wrapper.containsMatchingElement(<a href={uri} />)).toBe(true);
     });
 
-    it('should ignore changes in scheme ', () => {
+    it('should ignore changes in scheme', () => {
         const uri = `https://localhost${pathAndParams}`;
         const wrapper = shallow(<LinkedDataLink uri={uri} />);
         expect(wrapper.contains(<Link to={{pathname, search, hash}} />)).toBe(true);
+    });
+
+    it('should not break on an invalid url', () => {
+        const uri = `some-invalid-url`;
+        const wrapper = shallow(<LinkedDataLink uri={uri} />);
+        expect(wrapper.contains(<a href={uri} />)).toBe(true);
     });
 });

--- a/projects/mercury/src/utils/metadataUtils.js
+++ b/projects/mercury/src/utils/metadataUtils.js
@@ -200,6 +200,11 @@ export const createIri = (id) => `http://${window.location.hostname}/iri/${id}`;
  * @returns {string}
  */
 export const url2iri = (iri) => {
-    const url = new URL(iri);
-    return `http://${url.hostname}${url.pathname}${url.search}${url.hash}`;
+    try {
+        const url = new URL(iri);
+        return `http://${url.hostname}${url.pathname}${url.search}${url.hash}`;
+    } catch (e) {
+        console.warn("Invalid uri given to convert to iri", iri);
+        return iri;
+    }
 };

--- a/projects/mercury/src/utils/metadataUtils.test.js
+++ b/projects/mercury/src/utils/metadataUtils.test.js
@@ -318,6 +318,10 @@ describe('Metadata Utils', () => {
             expect(url2iri('scheme://example.com/some/path/?#')).toEqual('http://example.com/some/path/');
         });
 
+        it('return the unmodified uri if it is invalid', () => {
+            expect(url2iri('some-invalid-uri')).toEqual('some-invalid-uri');
+        });
+
     });
 
     describe('getTypeInfo', () => {


### PR DESCRIPTION
The frontend should fetch metadata from the backend with the same url as is entered in the address bar (so including query and fragment) with 2 exceptions: 
- an IRI must not contain a port number
- the IRI will always have scheme `http`

The reasons for that is:

> It seems that all standard ontologies use http. Also, same resource can be in principle accessed using both http and https.

This fixes both VRE-720 and VRE-721