### PR TITLE
Change sh:class property to generic IRI

### DIFF
--- a/projects/saturn/src/main/resources/default-vocabularies/meta-vocabulary.ttl
+++ b/projects/saturn/src/main/resources/default-vocabularies/meta-vocabulary.ttl
@@ -164,7 +164,10 @@ fs:RelationShapeMetaShape a sh:NodeShape ;
         sh:greaterThanOrEquals sh:minCount ;
         sh:name "Maximum number of values"
     ], [
-        sh:class fs:Class ;
+        # This nodeKind restriction could be replaced by something like
+        # sh:class fs:Class. Currently that restriction will limit our
+        # options to add new shapes
+        sh:nodeKind sh:IRI ;
         sh:path sh:class ;
         sh:maxCount 1 ;
         sh:minCount 1 ;


### PR DESCRIPTION
We currently do not have any Class entities in our vocabulary,
as we only work with shapes. However, this disables us to show
a dropdown of Class entities to choose from. For that reason, the
sh:class is now represented as generic IRI, where the user can
enter an arbitrary URI.

In the future this is likely to change, as we add more specific
functionality to the vocabulary editor.