### PR TITLE
Use FormControl in Property, add required for all

### DIFF
--- a/projects/mercury/src/components/metadata/common/LinkedDataProperty.test.js
+++ b/projects/mercury/src/components/metadata/common/LinkedDataProperty.test.js
@@ -1,13 +1,11 @@
 import React from 'react';
-import {shallow} from "enzyme";
-import {List, ListItem} from '@material-ui/core';
+import {mount} from "enzyme";
+import {FormGroup, FormControlLabel} from '@material-ui/core';
 import ClearIcon from '@material-ui/icons/Clear';
 
 import {STRING_URI} from "../../../constants";
 import LinkedDataProperty from "./LinkedDataProperty";
 import StringValue from "./values/StringValue";
-import ReferringValue from "./values/ReferringValue";
-import DateValue from "./values/DateValue";
 
 const defaultProperty = {
     key: 'description',
@@ -17,12 +15,6 @@ const defaultProperty = {
     maxValuesCount: 4
 };
 
-const mockComponentFactory = {
-    addComponent: () => StringValue,
-    editComponent: () => DateValue,
-    readOnlyComponent: () => ReferringValue
-};
-
 describe('LinkedDataProperty elements', () => {
     it('shows all provided values', () => {
         const property = {
@@ -30,27 +22,27 @@ describe('LinkedDataProperty elements', () => {
             maxValuesCount: 1
         };
 
-        const wrapper = shallow(<LinkedDataProperty editable property={property} />, {context: mockComponentFactory});
-        const listItems = wrapper.find(List).find(ListItem);
+        const wrapper = mount(<LinkedDataProperty editable property={property} />);
+        const listItems = wrapper.find(FormGroup).find(FormControlLabel);
 
         expect(listItems.length).toEqual(3);
     });
 
     it('shows an add element if multiple values are allowed, and it is editable', () => {
-        const wrapper = shallow(<LinkedDataProperty editable property={defaultProperty} />, {context: mockComponentFactory});
+        const wrapper = mount(<LinkedDataProperty editable property={defaultProperty} />);
 
-        const listItems = wrapper.find(List).find(ListItem);
+        const listItems = wrapper.find(FormGroup).find(FormControlLabel);
         expect(listItems.length).toEqual(4);
-        const deletIcons = wrapper.find(List).find(ClearIcon);
+        const deletIcons = wrapper.find(FormGroup).find(ClearIcon);
         expect(deletIcons.length).toEqual(3);
     });
 
     it('shows no add element if multiple values are allowed, but it is uneditable', () => {
-        const wrapper = shallow(<LinkedDataProperty editable={false} property={defaultProperty} />, {context: mockComponentFactory});
+        const wrapper = mount(<LinkedDataProperty editable={false} property={defaultProperty} />);
 
-        const listItems = wrapper.find(List).find(ListItem);
+        const listItems = wrapper.find(FormGroup).find(FormControlLabel);
         expect(listItems.length).toEqual(3);
-        const deletIcons = wrapper.find(List).find(ClearIcon);
+        const deletIcons = wrapper.find(FormGroup).find(ClearIcon);
         expect(deletIcons.length).toEqual(0);
     });
 
@@ -60,14 +52,13 @@ describe('LinkedDataProperty elements', () => {
             values: []
         };
 
-        const wrapper = shallow(<LinkedDataProperty editable property={property} />, {context: mockComponentFactory});
+        const wrapper = mount(<LinkedDataProperty editable property={property} />);
 
-        const listItems = wrapper.find(List).find(ListItem);
+        const listItems = wrapper.find(FormGroup).find(FormControlLabel);
         expect(listItems.length).toEqual(1);
 
         // Assert contents of the single component
-        const ExpectedComponent = mockComponentFactory.addComponent(property);
-        const inputComponent = listItems.at(0).dive().find(ExpectedComponent);
+        const inputComponent = listItems.at(0).find(StringValue);
         expect(inputComponent.prop('entry')).toEqual({value: ""});
     });
 
@@ -77,9 +68,9 @@ describe('LinkedDataProperty elements', () => {
             values: []
         };
 
-        const wrapper = shallow(<LinkedDataProperty editable={false} property={property} />, {context: mockComponentFactory});
+        const wrapper = mount(<LinkedDataProperty editable={false} property={property} />);
 
-        const listItems = wrapper.find(List).find(ListItem);
+        const listItems = wrapper.find(FormGroup).find(FormControlLabel);
         expect(listItems.length).toEqual(0);
     });
 
@@ -90,14 +81,13 @@ describe('LinkedDataProperty elements', () => {
             maxValuesCount: 1
         };
 
-        const wrapper = shallow(<LinkedDataProperty editable property={property} />, {context: mockComponentFactory});
+        const wrapper = mount(<LinkedDataProperty editable property={property} />);
 
-        const listItems = wrapper.find(List).find(ListItem);
+        const listItems = wrapper.find(FormGroup).find(FormControlLabel);
         expect(listItems.length).toEqual(1);
 
         // Assert contents of the single component
-        const ExpectedComponent = mockComponentFactory.editComponent(property);
-        const inputComponent = listItems.at(0).dive().find(ExpectedComponent);
+        const inputComponent = listItems.at(0).find(StringValue);
         expect(inputComponent.prop('entry').value).toEqual('More info');
     });
 
@@ -108,8 +98,8 @@ describe('LinkedDataProperty elements', () => {
             maxValuesCount: 2
         };
 
-        const wrapper = shallow(<LinkedDataProperty editable={false} property={property} />, {context: mockComponentFactory});
-        const listItems = wrapper.find(List).find(ListItem);
+        const wrapper = mount(<LinkedDataProperty editable={false} property={property} />);
+        const listItems = wrapper.find(FormGroup).find(FormControlLabel);
         expect(listItems.length).toEqual(2);
     });
 });

--- a/projects/mercury/src/components/metadata/common/LinkedDataValuesContext.js
+++ b/projects/mercury/src/components/metadata/common/LinkedDataValuesContext.js
@@ -1,5 +1,8 @@
 import React from "react";
 
+import StringValue from "./values/StringValue";
+import ReferringValue from "./values/ReferringValue";
+
 /**
  * This context represents the context for the linked data forms.
  *
@@ -7,4 +10,8 @@ import React from "react";
  *
  * @type {React.Context<{}>}
  */
-export const LinkedDataValuesContext = React.createContext({});
+export const LinkedDataValuesContext = React.createContext({
+    addComponent: () => StringValue,
+    editComponent: () => StringValue,
+    readOnlyComponent: () => ReferringValue
+});

--- a/projects/mercury/src/utils/linkeddata/vocabularyUtils.js
+++ b/projects/mercury/src/utils/linkeddata/vocabularyUtils.js
@@ -110,6 +110,7 @@ export const vocabularyUtils = (vocabulary = []) => {
         const datatype = getFirstPredicateId(shape, constants.SHACL_DATATYPE);
         const className = getFirstPredicateId(shape, constants.SHACL_CLASS);
         const multiLine = datatype === constants.STRING_URI && getFirstPredicateValue(shape, constants.SHACL_MAX_LENGTH, 1000) > 255;
+        const minValuesCount = getFirstPredicateValue(shape, constants.SHACL_MIN_COUNT);
 
         return {
             key: predicate,
@@ -118,6 +119,7 @@ export const vocabularyUtils = (vocabulary = []) => {
             datatype,
             multiLine,
             className,
+            minValuesCount,
             maxValuesCount: getFirstPredicateValue(shape, constants.SHACL_MAX_COUNT),
             machineOnly: getFirstPredicateValue(shape, constants.MACHINE_ONLY_URI, false),
             allowedValues: getFirstPredicateList(shape, constants.SHACL_IN),


### PR DESCRIPTION
The `LinkedDataProperty` has new implementation, mainly it uses `FormGroups` from MaterialUI for consistent UI and behavior. It also shows required fields with asterisk.
Also, after providing default implementation for `LinkedDataValuesContext`, there's no need `LinkedDataProperty.contextTypes` nor for mocking the context; plus `LinkedDataProperty` can be mounted with no errors.