### PR TITLE
Do not filter linked data dropdowns ourselves

### DIFF
--- a/projects/mercury/src/components/common/MaterialReactSelect.js
+++ b/projects/mercury/src/components/common/MaterialReactSelect.js
@@ -207,6 +207,7 @@ const materialReactSelect = (props) => {
             onChange={props.onChange}
             noOptionsMessage={props.noOptionsMessage}
             placeholder={props.placeholder}
+            filterOption={props.filterOption}
             textFieldProps={{
                 label: props.label,
                 InputLabelProps: {

--- a/projects/mercury/src/components/metadata/common/LinkedDataDropdown.js
+++ b/projects/mercury/src/components/metadata/common/LinkedDataDropdown.js
@@ -84,6 +84,7 @@ class LinkedDataDropdown extends React.Component {
         return (
             <Dropdown
                 {...otherProps}
+                filterOption={() => true}
                 onTextInputChange={this.onTextInputChange}
                 options={options}
             />


### PR DESCRIPTION
We use ES to search given the text that the user has typed. Therefore,
we do not need the select to perform any additional filtering, based
on label.