### PR TITLE
Stop asking for objectProperties when fetching full vocabulary

### DIFF
--- a/projects/mercury/src/actions/metadataActions.js
+++ b/projects/mercury/src/actions/metadataActions.js
@@ -48,7 +48,7 @@ export const createMetadataEntityFromState = (formKey, subject, type) => (dispat
 
 const fetchMetadataBySubject = createErrorHandlingPromiseAction(subject => ({
     type: actionTypes.FETCH_METADATA,
-    payload: MetadataAPI.get({subject}),
+    payload: MetadataAPI.get({subject, includeObjectProperties: true}),
     meta: {
         subject
     }

--- a/projects/mercury/src/services/LinkedDataAPI.js
+++ b/projects/mercury/src/services/LinkedDataAPI.js
@@ -40,11 +40,7 @@ class LinkedDataAPI {
     }
 
     get(params = {}) {
-        let query = '';
-        if (Object.entries(params).length > 0) {
-            params.includeObjectProperties = true;
-            query = Object.keys(params).map(key => `${key}=${encodeURIComponent(params[key])}`).join('&');
-        }
+        const query = Object.keys(params).map(key => `${key}=${encodeURIComponent(params[key])}`).join('&');
 
         return fetch(`${this.getStatementsUrl()}?${query}`, LinkedDataAPI.getParams)
             .then(failOnHttpError("Failure when retrieving metadata"))

--- a/projects/mercury/src/services/__tests__/LinkedDataAPI.js
+++ b/projects/mercury/src/services/__tests__/LinkedDataAPI.js
@@ -25,7 +25,7 @@ beforeAll(() => {
 
 it('fetches metadata with provided parameters', () => {
     window.fetch = jest.fn(() => Promise.resolve(mockResponse(200, 'OK', JSON.stringify([]))));
-    MetadataAPI.get({subject: 'a', predicate: 'b', object: 'c'});
+    MetadataAPI.get({subject: 'a', predicate: 'b', object: 'c', includeObjectProperties: true});
     expect(window.fetch.mock.calls[0][0]).toEqual("/meta/?subject=a&predicate=b&object=c&includeObjectProperties=true");
 });
 


### PR DESCRIPTION
When fetching everything from the database, it will automatically include
all properties of any possible object. As the query will be more
complicated when asking for the objectProperties, it is better not
to ask for them to improve performance.