### PR TITLE
Domain includes

### DIFF
--- a/projects/saturn/src/main/resources/default-vocabularies/meta-vocabulary.ttl
+++ b/projects/saturn/src/main/resources/default-vocabularies/meta-vocabulary.ttl
@@ -236,7 +236,7 @@ fs:domainIncludes a fs:RelationShape ;
     sh:class fs:ClassShape ;
     sh:order 3 ;
     sh:name "Domain Includes" ;
-    sh:description "All class shapes that have associate with this property." .
+    sh:description "All class shapes that include this property." .
 
 fs:fixedShapeShape a fs:DatatypePropertyShape ;
     sh:datatype xsd:boolean ;


### PR DESCRIPTION
This intends to allows users to set create triples `fs:classShape sh:property fs:PropertyShape` triples from the perspective of the propertyShape. This will help users identify both classes that are connected via a relation, as currently only one of the two classes is shown on a given page.