### PR TITLE
Download files using a separate download url on the same domain

### DIFF
--- a/charts/workspace/templates/projects/mercury/configmap.yaml
+++ b/charts/workspace/templates/projects/mercury/configmap.yaml
@@ -11,6 +11,7 @@ data:
   config.json: |-
     {
       "urls": {
+        "download": "{{ template "workspace.url" . }}/zuul/webdav/v1",
         "files": "{{ template "storage.url" . }}/webdav/v1"
         {{ if ( and .Values.services .Values.services.jupyterhub  ) }}, "jupyterhub": "{{ .Values.services.jupyterhub }}"{{ end }}
         {{ if ( and .Values.services .Values.services.cbioportal  ) }}, "cbioportal": "{{ .Values.services.cbioportal }}"{{ end }}

--- a/projects/mercury/src/config.json
+++ b/projects/mercury/src/config.json
@@ -6,6 +6,7 @@
     "collections": "/api/v1/collections/",
     "permissions": "/api/v1/permissions/",
     "files": "/webdav/v1",
+    "download": "/webdav/v1",
     "metadata": {
       "statements": "/api/v1/metadata/",
       "entities": "/api/v1/metadata/entities/"

--- a/projects/mercury/src/services/FileAPI.js
+++ b/projects/mercury/src/services/FileAPI.js
@@ -119,7 +119,7 @@ class FileAPI {
     /**
      * It creates a full download like to the path provided
      */
-    getDownloadLink = (path = '') => this.client().getFileDownloadLink(path, defaultOptions);
+    getDownloadLink = (path = '') => Config.get().urls.download + path;
 
     /**
      * Deletes the file given by path


### PR DESCRIPTION
This special url allows us to force downloading a file with the
download attribute on a link, because it is on the same domain as
the web application itself.

Fixes VRE-653