### PR TITLE
Require ES by default in kubernetes

### DIFF
--- a/charts/workspace/templates/projects/saturn/configmap.yaml
+++ b/charts/workspace/templates/projects/saturn/configmap.yaml
@@ -18,7 +18,7 @@ data:
       maxTriplesToReturn: {{ .Values.saturn.maxTriplesToReturn }}
       elasticSearch:
         enabled: {{ .Values.workspace.elasticsearch.enabled }}
-        required: false
+        required: true
         settings:
           hostToPortMapping:
             {{ template "workspace.elasticsearch.transporthost" . }}: {{ .Values.workspace.elasticsearch.transportport }}


### PR DESCRIPTION
This way Saturn will crash if ES cannot be reached properly. Kubernetes will
restart saturn until ES will be started correctly.