### PR TITLE
Add custom hook to keep track of isMounted state

### DIFF
--- a/projects/mercury/src/components/metadata/useFormSubmission.js
+++ b/projects/mercury/src/components/metadata/useFormSubmission.js
@@ -2,6 +2,7 @@ import {useState} from "react";
 import ErrorDialog from "../common/ErrorDialog";
 import ValidationErrorsDisplay from './common/ValidationErrorsDisplay';
 import {partitionErrors} from "../../utils/linkeddata/metadataUtils";
+import useIsMounted from "../../utils/useIsMounted";
 
 const onFormSubmissionError = (e, id) => {
     if (e.details) {
@@ -13,13 +14,14 @@ const onFormSubmissionError = (e, id) => {
 
 const useFormSubmission = (submitFunc, subject) => {
     const [isUpdating, setUpdating] = useState(false);
+    const isMounted = useIsMounted();
 
     const submitForm = () => {
         setUpdating(true);
 
         submitFunc()
             .catch(e => onFormSubmissionError(e, subject))
-            .then(() => setUpdating(false));
+            .then(() => isMounted() && setUpdating(false));
     };
 
     return {isUpdating, submitForm};

--- a/projects/mercury/src/services/Config/Config.js
+++ b/projects/mercury/src/services/Config/Config.js
@@ -30,6 +30,11 @@ class Config {
      * @returns {Promise<any> | *}
      */
     init() {
+        // Avoid double initialization
+        if (this.loadingPromise) {
+            return this.loadingPromise;
+        }
+
         // Load external configuration files. Please note that
         // if multiple files are provided, there is no guarantee
         // about ordering, so it is best for the configuration files

--- a/projects/mercury/src/utils/useIsMounted.js
+++ b/projects/mercury/src/utils/useIsMounted.js
@@ -1,0 +1,25 @@
+import {useRef, useEffect} from 'react';
+
+/**
+ * This custom hook keeps track of the mounted state of a component or hook.
+ *
+ * It can be used to safeguard promise callbacks from updating the state on a component
+ * that has been unmounted already.
+ *
+ * @returns {function(): boolean}
+ */
+const useIsMounted = () => {
+    const isMounted = useRef(false);
+
+    useEffect(() => {
+        isMounted.current = true;
+
+        return () => {
+            isMounted.current = false;
+        };
+    }, []);
+
+    return () => isMounted.current;
+};
+
+export default useIsMounted;


### PR DESCRIPTION
The custom hook makes it simple to check whether a component is still mounted.
In many cases, we update the state of a component in a promise callback. Due to
the asynchronous nature of promises, we are never certain that the component is still
mounted when the callback is executed. React warns about changing the state of
a component that is unmounted. This hook allows for an easy check whether the
component is unmounted, without polluting the component itself.