### PR TITLE
Avoid endless rendering on the new LD dialog

### DIFF
--- a/projects/mercury/src/components/metadata/UseFormData.js
+++ b/projects/mercury/src/components/metadata/UseFormData.js
@@ -21,10 +21,10 @@ const useFormData = (values) => {
     const valuesWithUpdates = {...values, ...updates};
 
     const save = (property, newValue) => {
-        setUpdates({
-            ...updates,
+        setUpdates(prev => ({
+            ...prev,
             [property.key]: newValue
-        });
+        }));
         validateProperty(property, newValue);
     };
 

--- a/projects/mercury/src/components/metadata/common/NewLinkedDataEntityDialog.js
+++ b/projects/mercury/src/components/metadata/common/NewLinkedDataEntityDialog.js
@@ -49,8 +49,9 @@ const NewLinkedDataEntityDialog = ({shape, requireIdentifier = true, onClose, on
     // Store the type to create in the form to ensure it is known
     // and will be stored
     useEffect(() => {
-        addValue('@type', {id: type});
-    });
+        addValue('@type', type);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const {isUpdating, submitForm} = useFormSubmission(
         () => createLinkedDataEntity(getIdentifier(), updates, type)
@@ -136,7 +137,7 @@ const NewLinkedDataEntityDialog = ({shape, requireIdentifier = true, onClose, on
                     color="primary"
                     disabled={!canCreate() || isUpdating || !isValid}
                 >
-                    {isUpdating ? <CircularProgress /> : 'Create' }
+                    {isUpdating ? <CircularProgress /> : 'Create'}
                 </Button>
             </DialogActions>
         </Dialog>


### PR DESCRIPTION
Prior to this PR NewLinkedDataEntityDialog would be endlessly rendered. To test add a console log NewLinkedDataEntityDialog and open it, the log would appear forever.