### PR TITLE
Handle empty strings as valid values when normalizing metadata.

### DIFF
--- a/projects/mercury/src/utils/linkeddata/__tests__/metadataUtils.js
+++ b/projects/mercury/src/utils/linkeddata/__tests__/metadataUtils.js
@@ -357,11 +357,11 @@ describe('Metadata Utils', () => {
             ]);
         });
 
-        it('should handle zero or false as actual values but not empty strings', () => {
+        it('should handle zero or false or empty strings as actual values', () => {
             expect(Object.values(normalizeMetadataResource({
-                a: [{value: 0, id: 'a'}, {value: false, id: 'b'}, {value: '', id: 'b'}],
+                a: [{value: 0, id: 'a'}, {value: false, id: 'b'}, {value: '', id: 'c'}],
             }))).toEqual([
-                [0, false, 'b']
+                [0, false, '']
             ]);
         });
     });

--- a/projects/mercury/src/utils/linkeddata/metadataUtils.js
+++ b/projects/mercury/src/utils/linkeddata/metadataUtils.js
@@ -298,7 +298,7 @@ export const normalizeMetadataResource = jsonLd => mapValues(
     values => (
         Array.isArray(values)
             ? values.map(v => {
-                if (isNonEmptyValue(v.value)) return v.value;
+                if (isNonEmptyValue(v.value) || v.value === '') return v.value;
                 return v.id || v;
             })
             : values


### PR DESCRIPTION
Fixes VRE-974