### PR TITLE
Load users list only for authorized logins

### DIFF
--- a/projects/mercury/src/App.js
+++ b/projects/mercury/src/App.js
@@ -12,7 +12,6 @@ import theme from './App.theme';
 import Layout from "./common/components/Layout/Layout";
 import {ErrorDialog, LoadingInlay} from './common/components';
 import {UserProvider} from './common/contexts/UserContext';
-import {UsersProvider} from "./common/contexts/UsersContext";
 import {VersionProvider} from './common/contexts/VersionContext';
 
 const App = () => {
@@ -34,19 +33,17 @@ const App = () => {
     return (
         <VersionProvider>
             <UserProvider>
-                <UsersProvider>
-                    <MuiPickersUtilsProvider utils={DateFnsUtils}>
-                        <MuiThemeProvider theme={theme}>
-                            <Provider store={store}>
-                                <ErrorDialog>
-                                    <Router>
-                                        <Layout />
-                                    </Router>
-                                </ErrorDialog>
-                            </Provider>
-                        </MuiThemeProvider>
-                    </MuiPickersUtilsProvider>
-                </UsersProvider>
+                <MuiPickersUtilsProvider utils={DateFnsUtils}>
+                    <MuiThemeProvider theme={theme}>
+                        <Provider store={store}>
+                            <ErrorDialog>
+                                <Router>
+                                    <Layout />
+                                </Router>
+                            </ErrorDialog>
+                        </Provider>
+                    </MuiThemeProvider>
+                </MuiPickersUtilsProvider>
             </UserProvider>
         </VersionProvider>
     );

--- a/projects/mercury/src/common/components/Layout/Layout.js
+++ b/projects/mercury/src/common/components/Layout/Layout.js
@@ -12,6 +12,7 @@ import {LoadingInlay} from "../index";
 import UserContext from '../../contexts/UserContext';
 import {LEFT_MENU_EXPANSION_DELAY, LOCAL_STORAGE_MENU_KEY} from "../../../constants";
 import VersionContext from '../../contexts/VersionContext';
+import {UsersProvider} from "../../contexts/UsersContext";
 
 const Layout = ({classes}) => {
     const [menuExpanded, setMenuExpanded] = useState(window.localStorage.getItem(LOCAL_STORAGE_MENU_KEY) !== 'false');
@@ -66,10 +67,12 @@ const Layout = ({classes}) => {
         <>
             <TopBar workspaceName={workspaceName} />
             <AuthorizationCheck authorization={Config.get().roles.user} transformError={transformError}>
-                <MenuDrawer open={menuOpen} toggleMenuExpansion={toggleMenuExpansion} onMouseLeave={handleMouseLeave} onMouseEnter={handleMouseEnter} />
-                <main style={{marginLeft: menuExpanded ? 175 : 0}} className={classes.main}>
-                    <Routes />
-                </main>
+                <UsersProvider>
+                    <MenuDrawer open={menuOpen} toggleMenuExpansion={toggleMenuExpansion} onMouseLeave={handleMouseLeave} onMouseEnter={handleMouseEnter} />
+                    <main style={{marginLeft: menuExpanded ? 175 : 0}} className={classes.main}>
+                        <Routes />
+                    </main>
+                </UsersProvider>
             </AuthorizationCheck>
             <Footer workspaceName={workspaceName} version={version} />
         </>


### PR DESCRIPTION
This prevents infinite redirects if the list of users is being loaded
for users that are not authorized to the workspace.