### PR TITLE
VRE-923 Render full date and some datetime UX enhancements

### DIFF
--- a/projects/mercury/src/constants.js
+++ b/projects/mercury/src/constants.js
@@ -12,7 +12,7 @@ export const COLLECTIONS_PATH = '/collections';
 export const METADATA_PATH = '/metadata';
 export const VOCABULARY_PATH = '/vocabulary';
 export const TOOLTIP_ENTER_DELAY = 350;
-
+export const DATE_FORMAT = 'dd/MM/yyyy';
 
 // Search
 export const COLLECTION_SEARCH_TYPE = 'collections';

--- a/projects/mercury/src/metadata/common/values/DateTimeValue.js
+++ b/projects/mercury/src/metadata/common/values/DateTimeValue.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import {DateTimePicker} from "material-ui-pickers";
+import {DATE_FORMAT} from '../../../constants';
 
 class DateTimeValue extends React.Component {
     constructor(props) {
@@ -27,6 +28,10 @@ class DateTimeValue extends React.Component {
 
         return (
             <DateTimePicker
+                showTodayButton
+                openTo="year"
+                format={`${DATE_FORMAT} hh:mm a`}
+                views={["year", "month", "day", "hours", "minutes"]}
                 {...otherProps}
                 value={this.state.value}
                 onChange={this.handleChange}

--- a/projects/mercury/src/metadata/common/values/DateValue.js
+++ b/projects/mercury/src/metadata/common/values/DateValue.js
@@ -2,6 +2,8 @@ import React from 'react';
 import {DatePicker} from "material-ui-pickers";
 import {format} from 'date-fns';
 
+import {DATE_FORMAT} from '../../../constants';
+
 class DateValue extends React.Component {
     constructor(props) {
         super(props);
@@ -17,7 +19,7 @@ class DateValue extends React.Component {
 
     handleChange = (date) => {
         // Formatting is required because the backend expect the date with no time
-        const value = format(date, 'yyyy-MM-dd', {awareOfUnicodeTokens: true});
+        const value = date && format(date, 'yyyy-MM-dd', {awareOfUnicodeTokens: true});
         this.props.onChange({value});
     }
 
@@ -30,6 +32,10 @@ class DateValue extends React.Component {
 
         return (
             <DatePicker
+                showTodayButton
+                openTo="year"
+                format={DATE_FORMAT}
+                views={["year", "month", "day"]}
                 {...otherProps}
                 value={this.state.value}
                 onChange={this.handleChange}


### PR DESCRIPTION
Beside the fix, this includes small UX enhancements:
- Opens on the year view first and user can pick: year -> month -> day (hours -> minutes)
  - It used to open directly on today's day, this change makes it more generic.
- An option to select today's date on one click.