### PR TITLE
No need to send match to FileOperations

### DIFF
--- a/projects/mercury/src/file/FileBrowser.js
+++ b/projects/mercury/src/file/FileBrowser.js
@@ -17,7 +17,6 @@ const TAB_UPLOAD = 'UPLOAD';
 
 export const FileBrowser = ({
     history,
-    match,
     files = [],
     openedCollection,
     openedPath,
@@ -108,9 +107,7 @@ export const FileBrowser = ({
                     />
                     <div style={{marginTop: 8}}>
                         <FileOperations
-                            match={match}
                             selectedPaths={selected}
-                            openedCollection={openedCollection}
                             openedPath={openedPath}
                             disabled={!openedCollection.canWrite}
                             getDownloadLink={FileAPI.getDownloadLink}

--- a/projects/mercury/src/file/FileOperations.js
+++ b/projects/mercury/src/file/FileOperations.js
@@ -199,10 +199,8 @@ export const FileOperations = ({
 };
 
 const mapStateToProps = (state, ownProps) => {
-    const {match: {params}, disabled: isWritingDisabled} = ownProps;
+    const {openedPath, disabled: isWritingDisabled} = ownProps;
     const {collectionBrowser: {selectedPaths}, cache: {filesByPath}, clipboard} = state;
-    const openedCollectionLocation = params.collection;
-    const openedPath = params.path ? `/${openedCollectionLocation}/${params.path}` : `/${openedCollectionLocation}`;
     const filesOfCurrentPath = (filesByPath[openedPath] || {}).data || [];
     const selectedItems = filesOfCurrentPath.filter(f => selectedPaths.includes(f.filename)) || [];
     const selectedItem = selectedItems && selectedItems.length === 1 ? selectedItems[0] : {};


### PR DESCRIPTION
I forgot to sync the change with the previous PR. "Match" is not actually needed.