### PR TITLE
Add configuraton configmaps needed for hooks as a hook as well.

### DIFF
--- a/charts/workspace/templates/config/keycloak-config-map.yaml
+++ b/charts/workspace/templates/config/keycloak-config-map.yaml
@@ -7,6 +7,10 @@ metadata:
     heritage: {{.Release.Service | quote }}
     release: {{.Release.Name | quote }}
     chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": hook-succeeded
 data:
   redirect.urls: |-
     {{ template "workspace.url" . }}/*

--- a/charts/workspace/templates/config/rabbitmq-config-map.yaml
+++ b/charts/workspace/templates/config/rabbitmq-config-map.yaml
@@ -7,6 +7,10 @@ metadata:
     heritage: {{.Release.Service | quote }}
     release: {{.Release.Name | quote }}
     chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": hook-succeeded
 data:
   rabbitmq.conf: |-
     [default]


### PR DESCRIPTION
The configmaps will be to k8s before install or after install, so
they can be used in a hook as well. The configmaps are removed after
the hook completes.