### PR TITLE
Use custom compare function for useLinkedDataSearch useEffects hook.

### DIFF
--- a/projects/mercury/src/common/hooks/UseDeepCompareEffect.js
+++ b/projects/mercury/src/common/hooks/UseDeepCompareEffect.js
@@ -1,0 +1,51 @@
+import {useEffect, useRef} from "react";
+
+const compareObjectsEqual = (o1, o2) => {
+    return JSON.stringify(o1) === JSON.stringify(o2);
+};
+
+/**
+ * Deep-compare two arrays of objects using JSON.stringify key-value pairs comparison (order of pairs matter)
+ * @param a1 - first array of objects
+ * @param a2 - second array of objects
+ * @returns {boolean|*} true if the arrays key-value pairs are equal.
+ */
+const compareArraysEqual = (a1, a2) => (
+    a1.length === a2.length
+    && a1.sort().every((value, index) => compareObjectsEqual(value, a2.sort()[index]))
+);
+
+const deepCompareEquals = (dependencies, refDependencies) => {
+    if (dependencies && refDependencies) {
+        return dependencies.every((dep, i) => {
+            if (dep instanceof Array) {
+                return compareArraysEqual(dep, refDependencies[i]);
+            }
+            if (dep instanceof Object) {
+                return compareObjectsEqual(dep, refDependencies[i]);
+            }
+            return dep === refDependencies[i];
+        });
+    }
+    return dependencies === refDependencies;
+};
+
+const useDeepCompareMemoize = (value) => {
+    const ref = useRef();
+    if (!deepCompareEquals(value, ref.current)) {
+        ref.current = value;
+    }
+    return ref.current;
+};
+
+/**
+ * Extension to a React useEffect hook.
+ * Uses custom dependencies comparison function, which, as opposed to the standard comparison for non-primitive types,
+ * compares objects by comparing key-value pairs, not by references.
+ *
+ * @param callback
+ * @param dependencies
+ */
+const useDeepCompareEffect = (callback, dependencies) => useEffect(callback, useDeepCompareMemoize(dependencies));
+
+export default useDeepCompareEffect;

--- a/projects/mercury/src/common/hooks/__tests__/UseDeepCompareEffect.js
+++ b/projects/mercury/src/common/hooks/__tests__/UseDeepCompareEffect.js
@@ -1,0 +1,87 @@
+import {renderHook} from '@testing-library/react-hooks';
+import useDeepCompareEffect from "../UseDeepCompareEffect";
+
+describe('UseDeepCompareEffect', () => {
+    const callback = jest.fn();
+
+    it('properly handles callbacks', () => {
+        let dependencies = [1, {a: 'b'}, 'test', false];
+        const {rerender} = renderHook(() => useDeepCompareEffect(callback, dependencies));
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        callback.mockClear();
+
+        // dependencies not changed
+        rerender();
+        expect(callback).toHaveBeenCalledTimes(0);
+        callback.mockClear();
+
+        // dependencies are a new object with same values
+        dependencies = [1, {a: 'b'}, 'test', false];
+        rerender();
+        expect(callback).toHaveBeenCalledTimes(0);
+        callback.mockClear();
+
+        // numeric dependency changed
+        dependencies = [2, {a: 'b'}, 'test', false];
+        rerender();
+        expect(callback).toHaveBeenCalledTimes(1);
+        callback.mockClear();
+
+        // textual dependency changed
+        dependencies = [2, {a: 'b'}, 'test2', false];
+        rerender();
+        expect(callback).toHaveBeenCalledTimes(1);
+        callback.mockClear();
+
+        // object dependency changed
+        dependencies = [2, {a: 'bb'}, 'test2', false];
+        rerender();
+        expect(callback).toHaveBeenCalledTimes(1);
+        callback.mockClear();
+    });
+
+    it('properly handles callbacks with dependencies of array type', () => {
+
+        let dependencies = [1, [{x: 1}, {y: 'z'}], true];
+        const {rerender} = renderHook(() => useDeepCompareEffect(callback, dependencies));
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        callback.mockClear();
+
+        // dependencies not changed
+        rerender();
+        expect(callback).toHaveBeenCalledTimes(0);
+        callback.mockClear();
+
+        // dependencies are a new object with same values
+        dependencies = [1, [{x: 1}, {y: 'z'}], true];
+        rerender();
+        expect(callback).toHaveBeenCalledTimes(0);
+        callback.mockClear();
+
+        // array dependency changes
+        dependencies = [1, [{x: 2}, {y: 'z'}], true];
+        rerender();
+        expect(callback).toHaveBeenCalledTimes(1);
+        callback.mockClear();
+
+        // array dependency changes
+        dependencies = [1, [{x: 2}, {y: 'zz'}], true];
+        rerender();
+        expect(callback).toHaveBeenCalledTimes(1);
+        callback.mockClear();
+
+        // array dependency changes
+        dependencies = [1, [{x: 2}, {y: 'zz'}, {z: 'new'}], true];
+        rerender();
+        expect(callback).toHaveBeenCalledTimes(1);
+        callback.mockClear();
+
+        // dependencies are the same
+        dependencies = [1, [{x: 2}, {y: 'zz'}, {z: 'new'}], true];
+        rerender();
+        expect(callback).toHaveBeenCalledTimes(0);
+        callback.mockClear();
+    });
+});

--- a/projects/mercury/src/metadata/UseLinkedDataSearch.js
+++ b/projects/mercury/src/metadata/UseLinkedDataSearch.js
@@ -1,4 +1,5 @@
-import {useContext, useEffect, useState} from 'react';
+import {useContext, useState} from 'react';
+import useDeepCompareEffect from "../common/hooks/UseDeepCompareEffect";
 
 import LinkedDataContext from './LinkedDataContext';
 
@@ -10,7 +11,7 @@ const useLinkedDataSearch = (selectedTypes, query, size, page, availableTypes) =
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState();
 
-    useEffect(() => {
+    useDeepCompareEffect(() => {
         // Only execute search if there are any availableTypes to query on,
         // i.e. when the shapes have been loaded
         if (availableTypes.length === 0 || shapesLoading) {
@@ -38,7 +39,7 @@ const useLinkedDataSearch = (selectedTypes, query, size, page, availableTypes) =
             })
             .catch((e) => setError(e || true))
             .finally(() => setLoading(false));
-    }, [query, shapesLoading, size, page, availableTypes, searchLinkedData, selectedTypes]);
+    }, [query, shapesLoading, size, page, searchLinkedData, selectedTypes, availableTypes]);
 
     return {
         searchPending: loading,


### PR DESCRIPTION
[VRE-1130](https://jira.thehyve.nl/browse/VRE-1130)

`useEffects` hook in [UseLinkedDataSearch.js](https://github.com/fairspace/workspace/blob/dev/projects/mercury/src/metadata/UseLinkedDataSearch.js#L13) was triggering the callback function each time the component was rerendered, even though values of dependencies were not changed. It is because 'availableTypes' dependency is a list of objects and dependency comparison in this hook for non-primitive types is done by reference, not by value. 