### PR TITLE
Fix displaying properties with empty description.

### DIFF
--- a/projects/mercury/src/common/utils/linkeddata/__tests__/jsonLdUtils.js
+++ b/projects/mercury/src/common/utils/linkeddata/__tests__/jsonLdUtils.js
@@ -70,7 +70,7 @@ describe('json-ld Utils', () => {
             expect(Object.values(normalizeJsonLdResource({
                 a: [{'@value': 0, '@id': 'a'}, {'@value': false, '@id': 'b'}, {'@value': '', '@id': 'b'}],
             }))).toEqual([
-                [0, false, 'b']
+                [0, false, '']
             ]);
         });
     });

--- a/projects/mercury/src/common/utils/linkeddata/jsonLdUtils.js
+++ b/projects/mercury/src/common/utils/linkeddata/jsonLdUtils.js
@@ -1,5 +1,4 @@
-import {mapValues} from 'lodash';
-import {isNonEmptyValue} from '../genericUtils';
+// @flow
 
 /**
  * Returns the value of the given property on the first entry of the predicate for the metadat
@@ -9,15 +8,15 @@ import {isNonEmptyValue} from '../genericUtils';
  * @param defaultValue      A default value to be returned if no value could be found for the metadata entry
  * @returns {*}
  */
-export const getFirstPredicateProperty = (metadataEntry, predicate, property, defaultValue) =>
+export const getFirstPredicateProperty = (metadataEntry: any, predicate: string, property: string, defaultValue: any): any =>
     // eslint-disable-next-line implicit-arrow-linebreak
     (metadataEntry && metadataEntry[predicate] && metadataEntry[predicate][0] ? metadataEntry[predicate][0][property] : defaultValue);
 
-export const getFirstPredicateValue = (metadataEntry, predicate, defaultValue) => getFirstPredicateProperty(metadataEntry, predicate, '@value', defaultValue);
+export const getFirstPredicateValue = (metadataEntry: any, predicate: string, defaultValue: any): any => getFirstPredicateProperty(metadataEntry, predicate, '@value', defaultValue);
 
-export const getFirstPredicateId = (metadataEntry, predicate, defaultValue) => getFirstPredicateProperty(metadataEntry, predicate, '@id', defaultValue);
+export const getFirstPredicateId = (metadataEntry: any, predicate: string, defaultValue: any): any => getFirstPredicateProperty(metadataEntry, predicate, '@id', defaultValue);
 
-export const getFirstPredicateList = (metadataEntry, predicate, defaultValue) => getFirstPredicateProperty(metadataEntry, predicate, '@list', defaultValue);
+export const getFirstPredicateList = (metadataEntry: any, predicate: string, defaultValue: any): any => getFirstPredicateProperty(metadataEntry, predicate, '@list', defaultValue);
 
 /**
  * Normalize a JSON-LD resource by converting the values or iris into a single object
@@ -28,14 +27,13 @@ export const getFirstPredicateList = (metadataEntry, predicate, defaultValue) =>
  * @param jsonLd
  * @returns {{}}
  */
-export const normalizeJsonLdResource = jsonLd => mapValues(
-    jsonLd,
-    values => (
-        Array.isArray(values)
-            ? values.map(v => {
-                if (isNonEmptyValue(v['@value'])) return v['@value'];
-                return v['@id'] || v;
-            })
-            : values
-    )
-);
+export const normalizeJsonLdResource = (jsonLd: any): any => Object.getOwnPropertyNames(jsonLd).reduce((res: any, key: string) => {
+    const values = jsonLd[key];
+    res[key] = Array.isArray(values)
+        ? values.map((v: any) => {
+            if (Object.prototype.hasOwnProperty.call(v, '@value')) return v['@value'];
+            return v['@id'] || v;
+        })
+        : values;
+    return res;
+}, {});

--- a/projects/mercury/src/common/utils/linkeddata/metadataUtils.js
+++ b/projects/mercury/src/common/utils/linkeddata/metadataUtils.js
@@ -300,7 +300,7 @@ export const normalizeMetadataResource = jsonLd => mapValues(
     values => (
         Array.isArray(values)
             ? values.map(v => {
-                if (isNonEmptyValue(v.value) || v.value === '') return v.value;
+                if (Object.prototype.hasOwnProperty.call(v, 'value')) return v.value;
                 return v.id || v;
             })
             : values

--- a/projects/mercury/src/workspaces/workspaces.js
+++ b/projects/mercury/src/workspaces/workspaces.js
@@ -7,7 +7,7 @@ export const currentWorkspace = () => {
     return ((segments.length > 2 && segments[0] === '' && segments[1] === 'workspaces') && segments[2]) || '';
 };
 
-export const workspacePrefix = (workspace = currentWorkspace()) => (workspace ? `/workspaces/${workspace}` : '');
+export const workspacePrefix = (workspace: string = currentWorkspace()) => (workspace ? `/workspaces/${workspace}` : '');
 
 axios.interceptors.request.use((config: AxiosRequestConfig) => {
     if (!config.url.startsWith('/')) {


### PR DESCRIPTION
Resolves the issue that empty descriptions are rendered as `[object Object]` in metadata property tables.

![Screenshot empty property as object](https://user-images.githubusercontent.com/7373499/74868916-4e59f580-5357-11ea-93b9-5aea82a4117c.png)
