### PR TITLE
Add workaround for history location pathname decoding

### DIFF
--- a/projects/mercury/src/file/FileBrowser.js
+++ b/projects/mercury/src/file/FileBrowser.js
@@ -63,7 +63,11 @@ export const DisconnectedFileBrowser = ({
 
     const handlePathDoubleClick = (path) => {
         if (path.type === 'directory') {
-            history.push(`/collections${encodePath(path.filename)}`);
+            /* TODO Remove additional encoding (encodeURI) after upgrading to history to version>=4.10
+             *      This version contains this fix: https://github.com/ReactTraining/history/pull/656
+             *      It requires react-router-dom version>=6 to be released.
+             */
+            history.push(`/collections${encodeURI(encodePath(path.filename))}`);
         } else {
             FileAPI.open(path.filename);
         }


### PR DESCRIPTION
Issue: Problem with opening files and directories containing '%' character.
General issue description: https://github.com/ReactTraining/history/issues/505 

Current solution is a workaround. There is a fix added to `history` library, version 4.10.0:
https://github.com/ReactTraining/history/pull/656
Current version of `react-router-dom` (5.1.2) that depends on `history` uses older version of this package: 4.9.0. There is no stable newer version of `react-router-dom`, only some buggy alpha versions.
After an upgrade of `react-router-dom` to v. 6.0.0 (as soon as it's released) we can remove this workaround.