### PR TITLE
Get rid of maxTriplesToReturn check

### DIFF
--- a/charts/fairspace/templates/projects/saturn/configmap.yaml
+++ b/charts/fairspace/templates/projects/saturn/configmap.yaml
@@ -19,7 +19,6 @@ data:
       storeParams:
 {{ toYaml .Values.saturn.storeParams | indent 8 }}
       transactionLogPath: "/data/saturn/files/log"
-      maxTriplesToReturn: {{ .Values.saturn.maxTriplesToReturn }}
       bulkTransactions: {{ .Values.saturn.bulkTransactions }}
       elasticSearch:
         enabled: {{ .Values.external.elasticsearch.enabled }}

--- a/charts/fairspace/values.yaml
+++ b/charts/fairspace/values.yaml
@@ -214,7 +214,6 @@ saturn:
       provisioner:
       allowVolumeExpansion: true
       reclaimPolicy: Delete
-  maxTriplesToReturn: 50000
   bulkTransactions: true
   # See Apache Jena TDB2 documentation
   storeParams:

--- a/projects/saturn/src/main/java/io/fairspace/saturn/config/Config.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/config/Config.java
@@ -54,8 +54,6 @@ public class Config {
 
         public File transactionLogPath = new File("data/log");
 
-        public long maxTriplesToReturn = 50000;
-
         public boolean bulkTransactions = true;
 
         public ElasticSearch elasticSearch = new ElasticSearch();

--- a/projects/saturn/src/main/java/io/fairspace/saturn/config/Services.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/config/Services.java
@@ -75,7 +75,7 @@ public class Services {
                 new WorkspaceStatusValidator(),
                 new ShaclValidator());
 
-        metadataService = new ChangeableMetadataService(transactions, defaultGraphIRI, VOCABULARY_GRAPH_URI, config.jena.maxTriplesToReturn, metadataLifeCycleManager, metadataValidator);
+        metadataService = new ChangeableMetadataService(transactions, defaultGraphIRI, VOCABULARY_GRAPH_URI, metadataLifeCycleManager, metadataValidator);
 
         var vocabularyValidator = new ComposedValidator(
                 new ProtectMachineOnlyPredicatesValidator(),
@@ -88,7 +88,7 @@ public class Services {
 
         var vocabularyLifeCycleManager = new MetadataEntityLifeCycleManager(dataset, VOCABULARY_GRAPH_URI, META_VOCABULARY_GRAPH_URI, permissionsService);
 
-        userVocabularyService = new ChangeableMetadataService(transactions, VOCABULARY_GRAPH_URI, META_VOCABULARY_GRAPH_URI, 0, vocabularyLifeCycleManager, vocabularyValidator);
+        userVocabularyService = new ChangeableMetadataService(transactions, VOCABULARY_GRAPH_URI, META_VOCABULARY_GRAPH_URI, vocabularyLifeCycleManager, vocabularyValidator);
         metaVocabularyService = new ReadableMetadataService(transactions, META_VOCABULARY_GRAPH_URI, META_VOCABULARY_GRAPH_URI);
 
         blobStore = new LocalBlobStore(new File(config.webDAV.blobStorePath));

--- a/projects/saturn/src/main/java/io/fairspace/saturn/services/metadata/ChangeableMetadataService.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/services/metadata/ChangeableMetadataService.java
@@ -26,8 +26,8 @@ public class ChangeableMetadataService extends ReadableMetadataService {
     private final MetadataEntityLifeCycleManager lifeCycleManager;
     private final MetadataRequestValidator validator;
 
-    public ChangeableMetadataService(Transactions transactions, Node graph, Node vocabulary, long tripleLimit, MetadataEntityLifeCycleManager lifeCycleManager, MetadataRequestValidator validator) {
-        super(transactions, graph, vocabulary, tripleLimit);
+    public ChangeableMetadataService(Transactions transactions, Node graph, Node vocabulary, MetadataEntityLifeCycleManager lifeCycleManager, MetadataRequestValidator validator) {
+        super(transactions, graph, vocabulary);
         this.lifeCycleManager = lifeCycleManager;
         this.validator = validator;
     }

--- a/projects/saturn/src/main/java/io/fairspace/saturn/services/metadata/ReadableMetadataApp.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/services/metadata/ReadableMetadataApp.java
@@ -42,7 +42,6 @@ public class ReadableMetadataApp extends BaseApp {
                 return serializer.serialize(getMetadata(req));
             });
         });
-        exception(TooManyTriplesException.class, exceptionHandler(SC_BAD_REQUEST, "Your query returned too many results"));
     }
 
     protected Model getMetadata(Request req) {

--- a/projects/saturn/src/test/java/io/fairspace/saturn/services/metadata/ChangeableMetadataServiceTest.java
+++ b/projects/saturn/src/test/java/io/fairspace/saturn/services/metadata/ChangeableMetadataServiceTest.java
@@ -51,7 +51,7 @@ public class ChangeableMetadataServiceTest {
     @Before
     public void setUp() {
         setupRequestContext();
-        api = new ChangeableMetadataService(txn, Quad.defaultGraphIRI, VOCABULARY_GRAPH_URI, 0, lifeCycleManager, new ComposedValidator());
+        api = new ChangeableMetadataService(txn, Quad.defaultGraphIRI, VOCABULARY_GRAPH_URI, lifeCycleManager, new ComposedValidator());
     }
 
     @Test

--- a/projects/saturn/src/test/java/io/fairspace/saturn/services/metadata/ChangeableMetadataServiceValidationTest.java
+++ b/projects/saturn/src/test/java/io/fairspace/saturn/services/metadata/ChangeableMetadataServiceValidationTest.java
@@ -68,7 +68,7 @@ public class ChangeableMetadataServiceValidationTest {
     public void setUp() {
         ds = createTxnMem();
         txn = new SimpleTransactions(ds);
-        api = new ChangeableMetadataService(txn, createURI(GRAPH), createURI(VOCABULARY), 0, lifeCycleManager, validator);
+        api = new ChangeableMetadataService(txn, createURI(GRAPH), createURI(VOCABULARY), lifeCycleManager, validator);
 
         setupRequestContext();
     }

--- a/projects/saturn/src/test/java/io/fairspace/saturn/services/metadata/ReadableMetadataServiceTest.java
+++ b/projects/saturn/src/test/java/io/fairspace/saturn/services/metadata/ReadableMetadataServiceTest.java
@@ -139,14 +139,6 @@ public class ReadableMetadataServiceTest {
         assertFalse(result.contains(S2, unimportantProperty, S3));
     }
 
-    @Test(expected = TooManyTriplesException.class)
-    public void testTripleLimit() {
-        api = new ReadableMetadataService(txn, createURI(GRAPH), createURI(userVocabularyURI), 1);
-        txn.executeWrite(ds -> ds.getNamedModel(GRAPH).add(STMT1).add(STMT2));
-
-        api.get(null, false);
-    }
-
     private void setupImportantProperties() {
         Resource labelShape = createResource("http://labelShape");
         Resource createdByShape = createResource("http://createdByShape");


### PR DESCRIPTION
Was necessary previously when it was possible to retrieve the entire database via metadata API