### PR TITLE
Keep the create collection dialog open after a failure.

### DIFF
--- a/projects/mercury/src/collections/CollectionBrowser.js
+++ b/projects/mercury/src/collections/CollectionBrowser.js
@@ -21,7 +21,8 @@ export const CollectionBrowser = ({
     history,
     workspaceIri,
     canAddCollection = true,
-    showDeleted
+    showDeleted,
+    setBusy = () => {}
 }) => {
     const [addingNewCollection, setAddingNewCollection] = useState(false);
 
@@ -52,6 +53,7 @@ export const CollectionBrowser = ({
                 />
                 {addingNewCollection ? (
                     <CollectionEditor
+                        setBusy={setBusy}
                         onClose={handleCancelAddCollection}
                         workspaceIri={workspaceIri}
                     />

--- a/projects/mercury/src/collections/CollectionDetails.js
+++ b/projects/mercury/src/collections/CollectionDetails.js
@@ -52,7 +52,6 @@ type CollectionDetailsProps = {
     collection: Collection;
     onChangeOwner: () => void;
     workspaces: Workspace[];
-    inCollectionsBrowser: boolean;
     deleteCollection: (Resource) => Promise<void>;
     undeleteCollection: (Resource) => Promise<void>;
     setStatus: (location: string, status: Status) => Promise<void>;
@@ -73,7 +72,6 @@ type CollectionDetailsState = {
 class CollectionDetails extends React.Component<CollectionDetailsProps, CollectionDetailsState> {
     static defaultProps = {
         onChangeOwner: () => {},
-        inCollectionsBrowser: false,
         setBusy: () => {}
     };
 
@@ -85,6 +83,12 @@ class CollectionDetails extends React.Component<CollectionDetailsProps, Collecti
         deleting: false,
         undeleting: false
     };
+
+    unmounting = false;
+
+    componentWillUnmount() {
+        this.unmounting = true;
+    }
 
     handleEdit = () => {
         if (this.props.collection.canWrite) {
@@ -250,7 +254,7 @@ class CollectionDetails extends React.Component<CollectionDetailsProps, Collecti
     );
 
     render() {
-        const {loading, error, collection, users, workspaceRoles, workspaces, inCollectionsBrowser = false} = this.props;
+        const {loading, error, collection, users, workspaceRoles, workspaces} = this.props;
         const {anchorEl, editing, changingStatus, changingOwner, deleting, undeleting} = this.state;
         const iconName = collection.type && ICONS[collection.type] ? collection.type : DEFAULT_COLLECTION_TYPE;
 
@@ -365,9 +369,8 @@ class CollectionDetails extends React.Component<CollectionDetailsProps, Collecti
                     <CollectionEditor
                         collection={collection}
                         updateExisting
-                        inCollectionsBrowser={inCollectionsBrowser}
                         setBusy={this.props.setBusy}
-                        onClose={() => this.setState({editing: false})}
+                        onClose={() => { if (!this.unmounting) { this.setState({editing: false})} }}
                     />
                 ) : null}
                 {changingStatus ? (

--- a/projects/mercury/src/collections/CollectionInformationDrawer.js
+++ b/projects/mercury/src/collections/CollectionInformationDrawer.js
@@ -137,7 +137,6 @@ export const CollectionInformationDrawer = (props: CollectionInformationDrawerPr
             <CollectionDetails
                 collection={collection}
                 onChangeOwner={props.onChangeOwner}
-                inCollectionsBrowser={props.inCollectionsBrowser}
                 loading={loading}
                 setBusy={props.setBusy}
             />

--- a/projects/mercury/src/collections/CollectionsPage.js
+++ b/projects/mercury/src/collections/CollectionsPage.js
@@ -82,6 +82,7 @@ const CollectionsPage = ({history, showBreadCrumbs, workspaceIri, classes}) => {
             <Grid container spacing={1}>
                 <Grid item className={classes.centralPanel}>
                     <CollectionBrowser
+                        setBusy={setBusy}
                         isSelected={collection => isSelected(collection.iri)}
                         toggleCollection={collection => toggleCollection(collection.iri)}
                         workspaceIri={workspaceIri}


### PR DESCRIPTION
E.g., when the collection name or id is already in use,
keep the dialog so that the user can retry with another name.

Fixes [VRE-1310](https://thehyve.atlassian.net/browse/VRE-1310).