### PR TITLE
Use bulk file upload API in the front-end

### DIFF
--- a/projects/mercury/src/file/FileAPI.js
+++ b/projects/mercury/src/file/FileAPI.js
@@ -122,6 +122,25 @@ class FileAPI {
             });
     }
 
+    uploadMulti(destinationPath, files, onUploadProgress = () => {}) {
+        const formData = new FormData();
+        formData.append('action', 'upload_files');
+        files.forEach(f => formData.append(f.path, f));
+        const requestOptions = {
+            method: "POST",
+            headers: {
+                "Accept": "text/plain",
+                "Content-Type": "multipart/form-data"
+            },
+            responseType: "text",
+            onUploadProgress,
+            data: formData
+        };
+        return this.client()
+            .customRequest(destinationPath, requestOptions)
+            .catch(handleHttpError("Error uploading files"));
+    }
+
     /**
      * It will calls the browser API to open the file if it's 'openable' otherwise the browser will show download dialog
      * @param path

--- a/projects/mercury/src/file/UploadsContext.js
+++ b/projects/mercury/src/file/UploadsContext.js
@@ -39,7 +39,7 @@ export const UploadsProvider = ({children, fileApi = FileAPI}) => {
             u => ({...u, progress: (progressEvent.loaded * 100) / progressEvent.total})
         );
         setStateForUpload(upload, UPLOAD_STATUS_IN_PROGRESS);
-        return fileApi.upload(upload, onUploadProgress)
+        return fileApi.uploadMulti(upload.destinationPath, [upload.file], onUploadProgress)
             .then(() => setStateForUpload(upload, UPLOAD_STATUS_FINISHED))
             .catch(() => setStateForUpload(upload, UPLOAD_STATUS_ERROR));
     };

--- a/projects/mercury/src/file/__tests__/UploadsContext.js
+++ b/projects/mercury/src/file/__tests__/UploadsContext.js
@@ -51,7 +51,7 @@ describe('UploadsProvider', () => {
     });
 
     it('should change state for uploads on start', async () => {
-        const getContext = getUploadsProviderValue({fileApi: {upload: () => Promise.resolve()}});
+        const getContext = getUploadsProviderValue({fileApi: {uploadMulti: () => Promise.resolve()}});
         let context;
 
         context = getContext();
@@ -85,7 +85,7 @@ describe('UploadsProvider', () => {
     });
 
     it('should handle upload errors', async () => {
-        const getContext = getUploadsProviderValue({fileApi: {upload: () => Promise.reject()}});
+        const getContext = getUploadsProviderValue({fileApi: {uploadMulti: () => Promise.reject()}});
         let context;
 
         context = getContext();
@@ -110,7 +110,7 @@ describe('UploadsProvider', () => {
 
     it('should store upload progress', async () => {
         const fileApi = {
-            upload: (upload, onProgress) => new Promise(resolve => {
+            uploadMulti: (destination, files, onProgress) => new Promise(resolve => {
                 // Set progress to 50 on start
                 onProgress({loaded: 1024, total: 2048});
 


### PR DESCRIPTION
UploadContext still uploads files one-by-one but now uses the bulk file upload API