### PR TITLE
Restrict search queries to only indexes accessible by the user.

### DIFF
--- a/projects/saturn/src/main/java/io/fairspace/saturn/config/SearchProxyServlet.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/config/SearchProxyServlet.java
@@ -1,0 +1,52 @@
+package io.fairspace.saturn.config;
+
+import io.fairspace.saturn.rdf.search.*;
+import io.fairspace.saturn.rdf.transactions.*;
+import io.fairspace.saturn.services.*;
+import org.eclipse.jetty.proxy.*;
+
+import javax.servlet.http.*;
+import java.util.*;
+
+public class SearchProxyServlet extends ProxyServlet {
+    final String apiPrefix;
+    final String elasticsearchUrl;
+    final IndexDispatcher indexDispatcher;
+    final Transactions tx;
+
+    public SearchProxyServlet(String apiPrefix, String elasticsearchUrl, Transactions tx, IndexDispatcher indexDispatcher) {
+        this.apiPrefix = apiPrefix;
+        this.elasticsearchUrl = elasticsearchUrl;
+        this.tx = tx;
+        this.indexDispatcher = indexDispatcher;
+    }
+
+    @Override
+    protected String rewriteTarget(HttpServletRequest clientRequest) {
+        var searchRequest = clientRequest.getRequestURI().replaceFirst(apiPrefix + "/search/", "");
+        var requestParts = searchRequest.split("/", 2);
+        if (requestParts[0].isEmpty()) {
+            return elasticsearchUrl;
+        }
+        var requestedIndices = Set.of(requestParts[0].split(","));
+        var suffix = requestParts.length > 1 ? requestParts[1] : "";
+        if (requestedIndices.contains("_search") && !suffix.isEmpty()) {
+            throw new IllegalArgumentException();
+        }
+        var availableIndices = tx.calculateRead(m -> Set.of(indexDispatcher.getAvailableIndexes()));
+        if (availableIndices.contains("_all")) {
+            return clientRequest.getRequestURI().replaceFirst(apiPrefix + "/search", elasticsearchUrl);
+        }
+        if (availableIndices.isEmpty()) {
+            throw new AccessDeniedException();
+        }
+        var indices = new HashSet<>(availableIndices);
+        if (!(requestedIndices.contains("_all") || requestedIndices.contains("_search"))) {
+            indices.retainAll(requestedIndices);
+        }
+        if (suffix.isEmpty()) {
+            return String.join("/", elasticsearchUrl, String.join(",", indices));
+        }
+        return String.join("/", elasticsearchUrl, String.join(",", indices), suffix);
+    }
+}

--- a/projects/saturn/src/main/java/io/fairspace/saturn/config/Services.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/config/Services.java
@@ -1,6 +1,6 @@
 package io.fairspace.saturn.config;
 
-import io.fairspace.saturn.rdf.search.FilteredDatasetGraph;
+import io.fairspace.saturn.rdf.search.*;
 import io.fairspace.saturn.rdf.transactions.BulkTransactions;
 import io.fairspace.saturn.rdf.transactions.SimpleTransactions;
 import io.fairspace.saturn.rdf.transactions.Transactions;
@@ -45,9 +45,9 @@ public class Services {
     private final DavFactory davFactory;
     private final HttpServlet davServlet;
     private final FilteredDatasetGraph filteredDatasetGraph;
+    private final SearchProxyServlet searchProxyServlet;
 
-
-    public Services(@NonNull Config config, @NonNull Dataset dataset) {
+    public Services(@NonNull String apiPrefix, @NonNull Config config, @NonNull Dataset dataset) {
         this.config = config;
         this.transactions = config.jena.bulkTransactions ? new BulkTransactions(dataset) : new SimpleTransactions(dataset);
 
@@ -76,5 +76,11 @@ public class Services {
         dataset.getContext().set(METADATA_SERVICE, metadataService);
 
         filteredDatasetGraph = new FilteredDatasetGraph(dataset.asDatasetGraph(), metadataPermissions);
+
+        searchProxyServlet = new SearchProxyServlet(
+                apiPrefix,
+                CONFIG.elasticsearchUrl,
+                transactions,
+                new IndexDispatcher(dataset.getContext()));
     }
 }

--- a/projects/saturn/src/main/java/io/fairspace/saturn/rdf/search/IndexDispatcher.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/rdf/search/IndexDispatcher.java
@@ -6,6 +6,8 @@ import io.milton.http.exceptions.NotAuthorizedException;
 import io.milton.resource.CollectionResource;
 import org.apache.jena.sparql.util.Context;
 
+import java.util.stream.*;
+
 import static io.fairspace.saturn.config.ConfigLoader.CONFIG;
 import static io.fairspace.saturn.config.Services.FS_ROOT;
 import static io.fairspace.saturn.config.Services.USER_SERVICE;
@@ -52,10 +54,13 @@ public class IndexDispatcher {
         }
 
         try {
-            return collectionsRoot.getChildren()
-                    .stream()
-                    .map(c -> COLLECTION_PREFIX + c.getName().toLowerCase())
-                    .toArray(String[]::new);
+            Stream<String> shared = userService.currentUser().isCanViewPublicMetadata()
+                    ? Stream.of(SHARED_INDEX) : Stream.empty();
+            return Stream.concat(
+                    shared,
+                    collectionsRoot.getChildren().stream()
+                            .map(c -> COLLECTION_PREFIX + c.getName().toLowerCase())
+            ).toArray(String[]::new);
         } catch (NotAuthorizedException | BadRequestException e) {
             throw new RuntimeException(e);
         }

--- a/projects/saturn/src/test/java/io/fairspace/saturn/config/SearchProxyServletTest.java
+++ b/projects/saturn/src/test/java/io/fairspace/saturn/config/SearchProxyServletTest.java
@@ -1,0 +1,106 @@
+package io.fairspace.saturn.config;
+
+import io.fairspace.saturn.rdf.search.*;
+import io.fairspace.saturn.rdf.transactions.*;
+import io.fairspace.saturn.services.*;
+import org.junit.*;
+import org.junit.runner.*;
+import org.mockito.*;
+import org.mockito.junit.*;
+
+import javax.servlet.http.*;
+
+import static org.apache.jena.query.DatasetFactory.createTxnMem;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SearchProxyServletTest {
+    static final String API_PREFIX = "/api";
+    static final String SEARCH_PREFIX = API_PREFIX + "/search";
+    static final String SEARCH_URL = "http://localhost:9200";
+
+    Transactions tx = new BulkTransactions(createTxnMem());
+
+    @Mock
+    IndexDispatcher indexDispatcher;
+
+    @Test
+    public void allowsAllForAdmins() {
+        when(indexDispatcher.getAvailableIndexes()).thenReturn(new String[] {"_all"});
+        var proxy = new SearchProxyServlet(API_PREFIX, SEARCH_URL, tx, indexDispatcher);
+
+        var request = mock(HttpServletRequest.class);
+        when(request.getRequestURI()).thenReturn(SEARCH_PREFIX + "/_all");
+        assertEquals(SEARCH_URL + "/_all", proxy.rewriteTarget(request));
+        when(request.getRequestURI()).thenReturn(SEARCH_PREFIX + "/_search");
+        assertEquals(SEARCH_URL + "/_search", proxy.rewriteTarget(request));
+        when(request.getRequestURI()).thenReturn(SEARCH_PREFIX + "/_all/_search");
+        assertEquals(SEARCH_URL + "/_all/_search", proxy.rewriteTarget(request));
+        when(request.getRequestURI()).thenReturn(SEARCH_PREFIX + "/_all/something/_search");
+        assertEquals(SEARCH_URL + "/_all/something/_search", proxy.rewriteTarget(request));
+    }
+
+    @Test
+    public void allowsSpecificIndicesForAdmins() {
+        when(indexDispatcher.getAvailableIndexes()).thenReturn(new String[] {"_all"});
+        var proxy = new SearchProxyServlet(API_PREFIX, SEARCH_URL, tx, indexDispatcher);
+
+        var request = mock(HttpServletRequest.class);
+        when(request.getRequestURI()).thenReturn(SEARCH_PREFIX + "/shared,collection_c1");
+        assertEquals(SEARCH_URL + "/shared,collection_c1", proxy.rewriteTarget(request));
+        when(request.getRequestURI()).thenReturn(SEARCH_PREFIX + "/shared,collection_c1/_search");
+        assertEquals(SEARCH_URL + "/shared,collection_c1/_search", proxy.rewriteTarget(request));
+        when(request.getRequestURI()).thenReturn(SEARCH_PREFIX + "/shared,collection_c1/something/_search");
+        assertEquals(SEARCH_URL + "/shared,collection_c1/something/_search", proxy.rewriteTarget(request));
+    }
+
+    @Test
+    public void restrictAllForNonAdmins() {
+        when(indexDispatcher.getAvailableIndexes()).thenReturn(new String[] {"shared", "collection_c1"});
+        var proxy = new SearchProxyServlet(API_PREFIX, SEARCH_URL, tx, indexDispatcher);
+
+        var request = mock(HttpServletRequest.class);
+        when(request.getRequestURI()).thenReturn(SEARCH_PREFIX + "/_all");
+        assertEquals(SEARCH_URL + "/shared,collection_c1", proxy.rewriteTarget(request));
+        when(request.getRequestURI()).thenReturn(SEARCH_PREFIX + "/_search");
+        assertEquals(SEARCH_URL + "/shared,collection_c1", proxy.rewriteTarget(request));
+        when(request.getRequestURI()).thenReturn(SEARCH_PREFIX + "/_all/_search");
+        assertEquals(SEARCH_URL + "/shared,collection_c1/_search", proxy.rewriteTarget(request));
+        when(request.getRequestURI()).thenReturn(SEARCH_PREFIX + "/_all/something/_search");
+        assertEquals(SEARCH_URL + "/shared,collection_c1/something/_search", proxy.rewriteTarget(request));
+    }
+
+    @Test
+    public void restrictSpecificIndicesForNonAdmins() {
+        when(indexDispatcher.getAvailableIndexes()).thenReturn(new String[] {"shared", "collection_c1"});
+        var proxy = new SearchProxyServlet(API_PREFIX, SEARCH_URL, tx, indexDispatcher);
+
+        var request = mock(HttpServletRequest.class);
+        when(request.getRequestURI()).thenReturn(SEARCH_PREFIX + "/shared");
+        assertEquals(SEARCH_URL + "/shared", proxy.rewriteTarget(request));
+        when(request.getRequestURI()).thenReturn(SEARCH_PREFIX + "/collection_c1,collection_c2/_search");
+        assertEquals(SEARCH_URL + "/collection_c1/_search", proxy.rewriteTarget(request));
+        when(request.getRequestURI()).thenReturn(SEARCH_PREFIX + "/shared,collection_c1,collection_c2/something/_search");
+        assertEquals(SEARCH_URL + "/shared,collection_c1/something/_search", proxy.rewriteTarget(request));
+    }
+
+    @Test(expected = AccessDeniedException.class)
+    public void searchDeniedForUsersWithoutAccess() {
+        when(indexDispatcher.getAvailableIndexes()).thenReturn(new String[] {});
+        var proxy = new SearchProxyServlet(API_PREFIX, SEARCH_URL, tx, indexDispatcher);
+
+        var request = mock(HttpServletRequest.class);
+        when(request.getRequestURI()).thenReturn(SEARCH_PREFIX + "/_all");
+        proxy.rewriteTarget(request);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void failOnIllegalSearchQuery() {
+        var proxy = new SearchProxyServlet(API_PREFIX, SEARCH_URL, tx, indexDispatcher);
+
+        var request = mock(HttpServletRequest.class);
+        when(request.getRequestURI()).thenReturn(SEARCH_PREFIX + "/_search/something");
+        proxy.rewriteTarget(request);
+    }
+}

--- a/projects/saturn/src/test/java/io/fairspace/saturn/config/ServicesTest.java
+++ b/projects/saturn/src/test/java/io/fairspace/saturn/config/ServicesTest.java
@@ -21,7 +21,7 @@ public class ServicesTest {
     @Before
     public void before() throws Exception {
         environmentVariables.set("KEYCLOAK_CLIENT_SECRET", "secret");
-        svc = new Services(config, dataset);
+        svc = new Services("/api/v1", config, dataset);
     }
 
     @Test


### PR DESCRIPTION
Fixes [VRE-1319](https://thehyve.atlassian.net/browse/VRE-1319).

Creating a separate (collection and metadata) search feature that only uses the Sparql endpoint is a separate effort. That would enable us to get rid of the Elasticsearch proxy altogether.