### PR TITLE
Fix display of file sizes, using base 10.

### DIFF
--- a/projects/mercury/src/file/FileList.js
+++ b/projects/mercury/src/file/FileList.js
@@ -162,7 +162,7 @@ const FileList = ({
                                     {file.basename}
                                 </TableCell>
                                 <TableCell align="right">
-                                    {file.type === 'file' ? filesize(file.size) : ''}
+                                    {file.type === 'file' ? filesize(file.size, {base: 10}) : ''}
                                 </TableCell>
                                 <TableCell align="right">
                                     {file.lastmod ? formatDateTime(file.lastmod) : null}


### PR DESCRIPTION
The filesize package uses by default 1 kB = 2^10 bytes,
which is incorect. 1kB = 10^3 bytes, see
https://en.wikipedia.org/wiki/Kilobyte.

Fixes [VRE-1163](https://thehyve.atlassian.net/browse/VRE-1163).