### PR TITLE
Display owner workspace name in collection table for external users.

### DIFF
--- a/projects/mercury/src/collections/CollectionList.js
+++ b/projects/mercury/src/collections/CollectionList.js
@@ -1,4 +1,4 @@
-import React, {useContext} from 'react';
+import React from 'react';
 import {
     ListItemText,
     Paper,
@@ -15,8 +15,6 @@ import {
 
 import styles from './CollectionList.styles';
 import {getDisplayName} from "../users/userUtils";
-import WorkspaceContext from "../workspaces/WorkspaceContext";
-import LoadingInlay from "../common/components/LoadingInlay";
 import MessageDisplay from "../common/components/MessageDisplay";
 import {camelCaseToWords, formatDateTime} from "../common/utils/genericUtils";
 import useSorting from "../common/hooks/UseSorting";
@@ -29,7 +27,7 @@ const baseColumns = {
         label: 'Name'
     },
     workspace: {
-        valueExtractor: 'workspaceName',
+        valueExtractor: 'ownerWorkspaceName',
         label: 'Workspace'
     },
     status: {
@@ -79,7 +77,6 @@ const CollectionList = ({
 
     const {orderedItems, orderAscending, orderBy, toggleSort} = useSorting(collectionsWithDisplayName, allColumns, 'name');
     const {page, setPage, rowsPerPage, setRowsPerPage, pagedItems} = usePagination(orderedItems);
-    const {workspaces, workspacesLoading} = useContext(WorkspaceContext);
 
     if (!collections || collections.length === 0) {
         return (
@@ -92,12 +89,6 @@ const CollectionList = ({
             />
         );
     }
-
-    if (workspacesLoading) {
-        return (<LoadingInlay />);
-    }
-
-    const pagedCollections = pagedItems.map(c => ({...c, workspaceName: workspaces.find(ws => ws.iri === c.ownerWorkspace).name}));
 
     return (
         <Paper className={classes.root}>
@@ -132,7 +123,7 @@ const CollectionList = ({
                         </TableRow>
                     </TableHead>
                     <TableBody>
-                        {pagedCollections.map((collection) => {
+                        {pagedItems.map((collection) => {
                             const selected = isSelected(collection);
 
                             return (
@@ -159,7 +150,7 @@ const CollectionList = ({
                                             maxWidth: 160
                                         }}
                                         >
-                                            {collection.workspaceName}
+                                            {collection.ownerWorkspaceName}
                                         </TableCell>
                                     ) }
                                     <TableCell>

--- a/projects/mercury/src/collections/__tests__/CollectionList.js
+++ b/projects/mercury/src/collections/__tests__/CollectionList.js
@@ -3,7 +3,6 @@ import '@testing-library/jest-dom/extend-expect';
 import {render} from '@testing-library/react';
 
 import CollectionList from "../CollectionList";
-import WorkspaceContext from "../../workspaces/WorkspaceContext";
 
 describe('CollectionList', () => {
     it('shows warning message when no collections available', () => {
@@ -19,13 +18,12 @@ describe('CollectionList', () => {
             },
             dateCreated: new Date().toUTCString(),
             iri: 'http://example.com/0',
-            ownerWorkspace: 'http://example.com/ws1'
+            ownerWorkspace: 'http://example.com/ws1',
+            ownerWorkspaceName: 'ws1'
         }];
 
         const {queryByText} = render(
-            <WorkspaceContext.Provider value={{workspaces: [{iri: 'http://example.com/ws1', name: 'ws1'}]}}>
-                <CollectionList collections={collections} showDeleted={false} />
-            </WorkspaceContext.Provider>
+            <CollectionList collections={collections} showDeleted={false} />
         );
 
         expect(queryByText('Name')).toBeInTheDocument();
@@ -47,13 +45,12 @@ describe('CollectionList', () => {
             dateCreated: new Date().toUTCString(),
             iri: 'http://example.com/0',
             ownerWorkspace: 'http://example.com/ws1',
+            ownerWorkspaceName: 'ws1',
             dateDeleted: new Date().toUTCString()
         }];
 
         const {getByText} = render(
-            <WorkspaceContext.Provider value={{workspaces: [{iri: 'http://example.com/ws1', name: 'ws1'}]}}>
-                <CollectionList collections={collections} showDeleted />
-            </WorkspaceContext.Provider>
+            <CollectionList collections={collections} showDeleted />
         );
 
         expect(getByText('Name')).toBeInTheDocument();

--- a/projects/mercury/src/collections/collectionUtils.js
+++ b/projects/mercury/src/collections/collectionUtils.js
@@ -100,6 +100,7 @@ export const mapFilePropertiesToCollection: Collection = (properties) => ({
     iri: properties.iri,
     name: properties.displayname,
     ownerWorkspace: properties.ownedBy,
+    ownerWorkspaceName: properties.ownedByName,
     location: properties.basename,
     description: properties.comment,
     dateCreated: properties.creationdate,

--- a/projects/mercury/src/metadata/common/LinkedDataLink.js
+++ b/projects/mercury/src/metadata/common/LinkedDataLink.js
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, {useContext} from 'react';
 import {Link as RouterLink} from "react-router-dom";
 import * as PropTypes from "prop-types";
 import {Link} from '@material-ui/core';
 import {METADATA_PATH} from "../../constants";
+import UserContext from '../../users/UserContext';
 
 /**
  * Renders a link to the metadata editor.
@@ -10,16 +11,22 @@ import {METADATA_PATH} from "../../constants";
  * @param props
  * @constructor
  */
-const LinkedDataLink = ({uri, children}) => (
-    <Link
-        component={RouterLink}
-        to={{pathname: METADATA_PATH, search: "?iri=" + encodeURIComponent(uri)}}
-        color="inherit"
-        underline="hover"
-    >
-        {children}
-    </Link>
-);
+const LinkedDataLink = ({uri, children}) => {
+    const {currentUser} = useContext(UserContext);
+    if (currentUser && currentUser.canViewPublicMetadata) {
+        return (
+            <Link
+                component={RouterLink}
+                to={{pathname: METADATA_PATH, search: "?iri=" + encodeURIComponent(uri)}}
+                color="inherit"
+                underline="hover"
+            >
+                {children}
+            </Link>
+        );
+    }
+    return children;
+};
 
 LinkedDataLink.propTypes = {
     uri: PropTypes.string.isRequired,

--- a/projects/saturn/src/main/java/io/fairspace/saturn/webdav/CollectionResource.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/webdav/CollectionResource.java
@@ -13,9 +13,7 @@ import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.RDFS;
 
-import java.util.EnumSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static io.fairspace.saturn.auth.RequestContext.getCurrentRequest;
 import static io.fairspace.saturn.rdf.ModelUtils.getStringProperty;
@@ -86,8 +84,15 @@ class CollectionResource extends DirectoryResource implements DisplayNameResourc
     }
 
     @Property
+    public String getOwnedByName() {
+        return Optional.ofNullable(subject.getPropertyResourceValue(FS.ownedBy))
+                .map(workspace -> getStringProperty(workspace, RDFS.label))
+                .orElse(null);
+    }
+
+    @Property
     public String getOwnedBy() {
-        return subject.listProperties(FS.ownedBy).nextOptional().map(Statement::getResource).map(Resource::getURI).orElse(null);
+        return Optional.ofNullable(subject.getPropertyResourceValue(FS.ownedBy)).map(Resource::getURI).orElse(null);
     }
 
     public void setOwnedBy(Resource owner) throws NotAuthorizedException, BadRequestException {


### PR DESCRIPTION
- Fix displaying owner workspace name for users that are not
  allowed to see all workspaces.
- Do not display a metadata link when the user does not have
  metadata view permission.

Fixes [VRE-1331](https://thehyve.atlassian.net/browse/VRE-1331).