### PR TITLE
Fix collection identifier helper text.

### DIFF
--- a/projects/mercury/src/collections/CollectionEditor.js
+++ b/projects/mercury/src/collections/CollectionEditor.js
@@ -272,9 +272,7 @@ export class CollectionEditor extends React.Component<CollectionEditorProps, Col
                         margin="dense"
                         id="location"
                         label="Collection identifier"
-                        helperText={this.editLocationEnabled
-                            ? 'This identifier does not allow special characters and has to be unique.'
-                            : 'Published collections cannot be moved.'}
+                        helperText={this.editLocationEnabled && 'This identifier does not allow special characters and has to be unique.'}
                         value={this.state.properties.location}
                         name="location"
                         onChange={(event) => this.handleInputChange('location', event.target.value)}


### PR DESCRIPTION
Remove the text about published collections, because the editor
is not available in that mode anyway.