### PR TITLE
Show asterisk as editing mark in the document title when editing.

### DIFF
--- a/projects/mercury/src/common/hooks/UsePageTitleUpdater.js
+++ b/projects/mercury/src/common/hooks/UsePageTitleUpdater.js
@@ -9,4 +9,19 @@ const UsePageTitleUpdater = title => {
     }, [title]);
 };
 
+export const UpdatePageTitleEditingMark = editing => {
+    useEffect(() => {
+        if (editing && !document.title.startsWith('* ')) {
+            document.title = `* ${document.title}`;
+        } else if (!editing && document.title.startsWith('* ')) {
+            document.title = document.title.substring(2);
+        }
+        return () => {
+            if (document.title.startsWith('* ')) {
+                document.title = document.title.substring(2);
+            }
+        };
+    }, [editing]);
+};
+
 export default UsePageTitleUpdater;

--- a/projects/mercury/src/metadata/common/LinkedDataEntityFormContainer.js
+++ b/projects/mercury/src/metadata/common/LinkedDataEntityFormContainer.js
@@ -11,6 +11,7 @@ import useNavigationBlocker from "../../common/hooks/UseNavigationBlocker";
 import useLinkedData from "./UseLinkedData";
 import {DATE_DELETED_URI} from "../../constants";
 import ConfirmationDialog from "../../common/components/ConfirmationDialog";
+import {UpdatePageTitleEditingMark} from '../../common/hooks/UsePageTitleUpdater';
 
 const LinkedDataEntityFormContainer = ({
     subject, typeInfo, hasEditRight = true, showEditButtons = false, fullpage = false,
@@ -44,6 +45,8 @@ const LinkedDataEntityFormContainer = ({
     const {
         confirmationShown, hideConfirmation, executeNavigation
     } = useNavigationBlocker(hasFormUpdates && editingEnabled);
+
+    UpdatePageTitleEditingMark(hasFormUpdates && editingEnabled);
 
     // Apply context-specific logic to the properties and filter on visibility
     const extendedProperties = extendProperties({properties, subject, isEntityEditable: editingEnabled});


### PR DESCRIPTION
Remind the user in a subtle way that metadata updates have
not yet been submitted.