### PR TITLE
Fix metadata permissions for file system resource for non-admin users.

### DIFF
--- a/projects/saturn/src/main/java/io/fairspace/saturn/webdav/DavFactory.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/webdav/DavFactory.java
@@ -60,7 +60,9 @@ public class DavFactory implements ResourceFactory {
     public Access getAccess(org.apache.jena.rdf.model.Resource subject) {
         var uri = subject.getURI();
         var nextSeparatorPos = uri.indexOf('/', rootSubject.getURI().length() + 1);
-        var coll = nextSeparatorPos < 0 ? subject : subject.getModel().createResource(uri.substring(0, nextSeparatorPos));
+        var coll = nextSeparatorPos < 0 ?
+                rootSubject.getModel().createResource(uri.substring(0)) :
+                rootSubject.getModel().createResource(uri.substring(0, nextSeparatorPos));
         if (!coll.hasProperty(RDF.type, FS.Collection)) {
             return Access.None;
         }
@@ -82,7 +84,7 @@ public class DavFactory implements ResourceFactory {
             access = Access.List;
         }
 
-        var userWorkspacesIterator = subject.getModel()
+        var userWorkspacesIterator = rootSubject.getModel()
                 .listSubjectsWithProperty(RDF.type, FS.Workspace)
                 .filterKeep(ws -> user.hasProperty(FS.isManagerOf, ws) || user.hasProperty(FS.isMemberOf, ws))
                 .filterDrop(ws -> ws.hasProperty(FS.dateDeleted));


### PR DESCRIPTION
The metadata permission check for metadata changes on files and collections would fail for regular (non-admin) users, because the permission check would be performed on a partial model (containing only the changes, not, e.g., the types and ownership information).