### PR TITLE
Force clear session storage on logout and session expiration

### DIFF
--- a/projects/mercury/src/common/utils/httpUtils.js
+++ b/projects/mercury/src/common/utils/httpUtils.js
@@ -12,6 +12,7 @@ import ErrorDialog from "../components/ErrorDialog";
 export const handleAuthError = (status) => {
     switch (status) {
         case 401:
+            sessionStorage.clear();
             ErrorDialog.showError('Your session has expired. Please log in again.',
                 null,
                 () => window.location.assign(`/login?redirectUrl=${encodeURI(window.location.href)}`));

--- a/projects/mercury/src/routes/logout.js
+++ b/projects/mercury/src/routes/logout.js
@@ -3,5 +3,8 @@ import {logoutUser} from "../users/UsersAPI";
 export default function logout() {
     const navigateToRoot = () => {window.location.href = '/';};
 
-    return logoutUser().then(navigateToRoot);
+    return logoutUser().then(() => {
+        sessionStorage.clear();
+        navigateToRoot();
+    });
 }


### PR DESCRIPTION
Apparently, session storage is cleared only when the page session ends, not the user session. Clearing this storage on user session expiration/logout has to be added separately. 