### PR TITLE
VRE-1392 - Fix showing view count when less results than rows per page

### DIFF
--- a/projects/mercury/src/metadata/views/MetadataView.js
+++ b/projects/mercury/src/metadata/views/MetadataView.js
@@ -1,4 +1,4 @@
-import React, {useContext, useEffect, useState} from 'react';
+import React, {useContext, useState} from 'react';
 import {Button, Grid, withStyles} from '@material-ui/core';
 import Tabs from "@material-ui/core/Tabs";
 import Tab from "@material-ui/core/Tab";
@@ -12,10 +12,7 @@ import MetadataViewContext from "./MetadataViewContext";
 import BreadcrumbsContext from "../../common/contexts/BreadcrumbsContext";
 import {getLocationContextFromString, getMetadataViewNameFromString} from "../../search/searchUtils";
 import type {MetadataViewEntity} from "./metadataViewUtils";
-import {
-    getMetadataViewsPath,
-    ofRangeValueType,
-} from "./metadataViewUtils";
+import {getMetadataViewsPath, ofRangeValueType,} from "./metadataViewUtils";
 import MetadataViewActiveFilters from "./MetadataViewActiveFilters";
 import MetadataViewInformationDrawer from "./MetadataViewInformationDrawer";
 import {useSingleSelection} from "../../file/UseSelection";
@@ -49,21 +46,15 @@ export const MetadataView = (props: MetadataViewProperties) => {
 
     usePageTitleUpdater("Metadata views");
 
-    const currentViewIndex = Math.max(0, views.map(v => v.name).indexOf(currentViewName));
-    const currentView = views[currentViewIndex];
-
-    const {updateFilters, clearFilter, clearAllFilters, setLocationFilter} = useContext(MetadataViewContext);
+    const {updateFilters, clearFilter, clearAllFilters} = useContext(MetadataViewContext);
     const {toggle, selected} = useSingleSelection();
     const [filterCandidates, setFilterCandidates] = useState([]);
     const {collections} = useContext(CollectionsContext);
 
-    // pass location filter to the API for files view
-    useEffect(() => {
-        setLocationFilter(locationContext);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [locationContext]);
-
     const toggleRow = (entity: MetadataViewEntity) => (toggle(entity));
+
+    const currentViewIndex = Math.max(0, views.map(v => v.name).indexOf(currentViewName));
+    const currentView = views[currentViewIndex];
 
     const a11yProps = (index) => ({
         'key': `metadata-view-tab-${index}`,

--- a/projects/mercury/src/metadata/views/MetadataViewContext.js
+++ b/projects/mercury/src/metadata/views/MetadataViewContext.js
@@ -7,18 +7,12 @@ import {isNonEmptyValue} from "../../common/utils/genericUtils";
 
 const MetadataViewContext = React.createContext({});
 
-const LOCATION_FILTER_FIELD = 'location';
 const SESSION_STORAGE_METADATA_FILTERS_KEY = 'FAIRSPACE_METADATA_FILTERS';
-const SESSION_STORAGE_USE_LOCATION_CONTEXT_KEY = 'FAIRSPACE_USE_LOCATION_CONTEXT';
 
 export const MetadataViewProvider = ({children, metadataViewApi = MetadataViewAPI}) => {
     const {data = {}, error, loading, refresh} = useAsync(
         () => metadataViewApi.getViews(),
         []
-    );
-
-    const [useLocationContext, setUseLocationContext] = useStateWithSessionStorage(
-        SESSION_STORAGE_USE_LOCATION_CONTEXT_KEY, false
     );
 
     const [filters: MetadataViewFilter[], setFilters] = useStateWithSessionStorage(
@@ -40,22 +34,6 @@ export const MetadataViewProvider = ({children, metadataViewApi = MetadataViewAP
         ]);
     };
 
-    const setLocationFilter = (locationContext: string) => {
-        if (!locationContext) {
-            if (useLocationContext) {
-                clearFilter(LOCATION_FILTER_FIELD);
-            }
-            setUseLocationContext(false);
-        } else {
-            const newFilter: MetadataViewFilter = {
-                field: LOCATION_FILTER_FIELD,
-                values: [locationContext]
-            };
-            setFilters([...filters.filter(f => ![LOCATION_FILTER_FIELD].includes(f.field)), newFilter]);
-            setUseLocationContext(true);
-        }
-    };
-
     return (
         <MetadataViewContext.Provider
             value={{
@@ -63,7 +41,6 @@ export const MetadataViewProvider = ({children, metadataViewApi = MetadataViewAP
                 facets: data.facets,
                 resourcesView: data.resourcesView,
                 filters,
-                setLocationFilter,
                 updateFilters,
                 clearAllFilters,
                 clearFilter,

--- a/projects/mercury/src/metadata/views/MetadataViewTableContainer.js
+++ b/projects/mercury/src/metadata/views/MetadataViewTableContainer.js
@@ -66,7 +66,7 @@ const LOCAL_STORAGE_METADATA_TABLE_ROWS_NUM_KEY = 'FAIRSPACE_METADATA_TABLE_ROWS
 const SESSION_STORAGE_VISIBLE_COLUMNS_KEY_PREFIX = 'FAIRSPACE_METADATA_VISIBLE_COLUMNS';
 
 export const MetadataViewTableContainer = (props: MetadataViewTableContainerProperties) => {
-    const {view, filters, columns, hasInactiveFilters, classes} = props;
+    const {view, filters, columns, hasInactiveFilters, locationContext, classes} = props;
 
     const [page, setPage] = useState(0);
     const [visibleColumnNames, setVisibleColumnNames] = useStateWithLocalStorage(
@@ -80,7 +80,7 @@ export const MetadataViewTableContainer = (props: MetadataViewTableContainerProp
     const columnSelectorOpen = Boolean(anchorEl);
     const history = useHistory();
 
-    const {data, count, countTimeout, error, loading, refreshDataOnly} = useViewData(view, filters, rowsPerPage);
+    const {data, count, countTimeout, error, loading, refreshDataOnly} = useViewData(view, filters, locationContext, rowsPerPage);
 
     useEffect(() => {setPage(0);}, [filters]);
 


### PR DESCRIPTION
Fixes [VRE-1392](https://thehyve.atlassian.net/browse/VRE-1392) - showing invalid count

The change here is to cancel previous `/count` call, if there is already a new `views` data call that does not require calling for count (count based on number of data rows - no next page) - otherwise results of old `count` call overwrite the new count, causing displayed number to be invalid.

Other issue to be fixed - when going to `Advanced search` from file browser the `GET views` call is triggered twice  - first time because the view state is changed, second - because the location filter is set.