### PR TITLE
Make sure the unique id of the root resource is the URI.

### DIFF
--- a/projects/saturn/src/main/java/io/fairspace/saturn/webdav/RootResource.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/webdav/RootResource.java
@@ -130,7 +130,7 @@ class RootResource implements io.milton.resource.CollectionResource, MakeCollect
 
     @Override
     public String getUniqueId() {
-        return factory.rootSubject.toString();
+        return factory.rootSubject.getURI();
     }
 
     @Override


### PR DESCRIPTION
Not sure what toString() does, perhaps the same, but let's
avoid that ambiguity.