### PR TITLE
Improve metadata upload template and header parsing feedback

### DIFF
--- a/projects/mercury/src/collections/CollectionInformationDrawer.js
+++ b/projects/mercury/src/collections/CollectionInformationDrawer.js
@@ -110,12 +110,12 @@ const generateTemplate = (vocabulary) => {
     ]);
 
     return '#   This section describes the CSV-based format used for bulk metadata uploads.\n'
-        + '#   Entity types can referenced by ID; multiple values must be separated by the pipe symbol |.\n'
+        + '#   Entity types can be referenced by ID or unique label; multiple values must be separated by the pipe symbol |.\n'
         + '#\n'
         + table([
             ['#', 'COLUMN', 'DESCRIPTION', 'TYPE', 'CARDINALITY', 'PREDICATE'],
-            ['#', 'Path', 'A relative path to a file or a directory, use ./ for the current directory or collection.', 'string', '1..1', ''],
-            ...doc]) + '\n\n'
+            ['#', 'Path', 'A relative path to a file or a directory; use ./ for the current directory or collection.', 'string', '1..1', ''],
+            ...doc]) + '\n#\n'
         + '"Path",' + uniqueProps.map(ps => JSON.stringify(getFirstPredicateValue(ps, SHACL_NAME))).join(',') + '\n'
         + '<PUT YOUR DATA HERE>\n';
 };

--- a/projects/saturn/src/main/java/io/fairspace/saturn/webdav/DirectoryResource.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/webdav/DirectoryResource.java
@@ -318,7 +318,8 @@ class DirectoryResource extends BaseResource implements FolderResource, Deletabl
                     }
                 }
             }
-        } catch (IOException e) {
+        } catch (IllegalArgumentException | IOException e) {
+            setErrorMessage(e.getMessage());
             throw new BadRequestException("Error parsing file " + file.getName(), e);
         }
 

--- a/projects/saturn/src/test/java/io/fairspace/saturn/webdav/DirectoryResourceTest.java
+++ b/projects/saturn/src/test/java/io/fairspace/saturn/webdav/DirectoryResourceTest.java
@@ -182,6 +182,17 @@ public class DirectoryResourceTest {
     }
 
     @Test(expected = BadRequestException.class)
+    public void testMetadataUploadEmptyHeader() throws NotAuthorizedException, ConflictException, BadRequestException {
+        String csv =
+                ",\n" +
+                        "./coll1,\"Blah blah\"\n";
+        when(file.getInputStream()).thenReturn(new ByteArrayInputStream(csv.getBytes()));
+        dir = (DirectoryResource) davFactory.getResource(null, BASE_PATH + "/coll1");
+
+        dir.processForm(Map.of("action", "upload_metadata"), Map.of("file", file));
+    }
+
+    @Test(expected = BadRequestException.class)
     public void testMetadataUploadUnknownFile() throws NotAuthorizedException, ConflictException, BadRequestException {
         String csv =
                 "Path,Description\n" +


### PR DESCRIPTION
[VRE-1413](https://thehyve.atlassian.net/browse/VRE-1413)

- show CSVParser parsing errors to the user, handle IllegalArgumentException of CSVParser
- remove an empty line from metadata template file (that is being overwritten by .csv reading programs to invalid empty values header)
- update the text in the metadata template file