### PR TITLE
Move the resource type facet values query to the backend.

### DIFF
--- a/projects/saturn/src/main/java/io/fairspace/saturn/config/ViewsConfig.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/config/ViewsConfig.java
@@ -86,7 +86,6 @@ public class ViewsConfig {
             @NotBlank public String title;
             @NotNull public ColumnType type;
             @NotBlank public String source;
-            public String query;
             public String rdfType;
             public int priority;
         }

--- a/projects/saturn/src/main/java/io/fairspace/saturn/services/views/ViewService.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/services/views/ViewService.java
@@ -32,6 +32,18 @@ public class ViewService {
             } ORDER BY ?label
             """, FS.NS));
 
+    private static final Query RESOURCE_TYPE_VALUES_QUERY = QueryFactory.create(String.format("""
+          PREFIX fs: <%s>
+          SELECT ?value ?label
+          WHERE {
+             VALUES (?value ?label) {
+                (fs:Collection "Collection")
+                (fs:Directory "Directory")
+                (fs:File "File")
+             }
+          }
+          """, FS.NS));
+
     private static final Query BOUNDS_QUERY = QueryFactory.create(String.format("""
             PREFIX fs: <%s>
 
@@ -65,8 +77,8 @@ public class ViewService {
 
         switch (column.type) {
             case Term, TermSet -> {
-                var query = (column.query != null && !column.query.isEmpty())
-                        ? QueryFactory.create(column.query)
+                var query = (view.name.equalsIgnoreCase("Resource") && column.name.equalsIgnoreCase("type"))
+                        ? RESOURCE_TYPE_VALUES_QUERY
                         : VALUES_QUERY;
                 var binding = new QuerySolutionMap();
                 binding.add("type", createResource(column.rdfType));

--- a/projects/saturn/views.yaml
+++ b/projects/saturn/views.yaml
@@ -160,16 +160,6 @@ views:
         title: Resource type
         source: http://www.w3.org/1999/02/22-rdf-syntax-ns#type
         type: term
-        query: |
-          PREFIX fs: <https://fairspace.nl/ontology#>
-          SELECT ?value ?label
-          WHERE {
-            VALUES (?value ?label) {
-              (fs:Collection "Collection")
-              (fs:Directory "Directory")
-              (fs:File "File")
-            }
-          }
       - name: dateCreated
         title: File created
         source: https://fairspace.nl/ontology#dateCreated


### PR DESCRIPTION
This prevents having to include the resource type query for each deployment (e.g., micromais).