### PR TITLE
Fix inclusion of the view config in the config map template.

### DIFF
--- a/charts/fairspace/templates/projects/saturn/configmap.yaml
+++ b/charts/fairspace/templates/projects/saturn/configmap.yaml
@@ -48,7 +48,7 @@ data:
 {{ end }}
   views.yaml: |
 {{ if .Values.saturn.views -}}
-{{ toYaml .Values.saturn.views | indent 4 -}}
+{{ .Values.saturn.views | indent 4 -}}
 {{ else -}}
 {{ .Files.Get "views.yaml" | indent 4 -}}
 {{ end }}


### PR DESCRIPTION
Found while trying the new version on the `sils` environment.