### PR TITLE
Handle IllegalStateException thrown by CSV formatter

### DIFF
--- a/projects/saturn/src/main/java/io/fairspace/saturn/webdav/DirectoryResource.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/webdav/DirectoryResource.java
@@ -321,6 +321,9 @@ class DirectoryResource extends BaseResource implements FolderResource, Deletabl
         } catch (IllegalArgumentException | IOException e) {
             setErrorMessage(e.getMessage());
             throw new BadRequestException("Error parsing file " + file.getName(), e);
+        } catch (IllegalStateException e) {
+            setErrorMessage("Metadata file is not a valid comma separated values file (CSV).");
+            throw new BadRequestException("Error parsing file " + file.getName(), e);
         }
 
         MetadataService metadataService = factory.context.get(METADATA_SERVICE);


### PR DESCRIPTION
Fixes [VRE-1420](https://thehyve.atlassian.net/browse/VRE-1420) - Error message unclear when using double quotations inside text 