### PR TITLE
Move metadata views TablePagination inside LoadingOverlayWrapper

### DIFF
--- a/projects/mercury/src/metadata/views/MetadataViewTableContainer.js
+++ b/projects/mercury/src/metadata/views/MetadataViewTableContainer.js
@@ -211,18 +211,18 @@ export const MetadataViewTableContainer = (props: MetadataViewTableContainerProp
                         />
                     )}
                 </TableContainer>
+                <TablePagination
+                    rowsPerPageOptions={[5, 10, 25, 100]}
+                    component="div"
+                    count={count && isNonEmptyValue(count.count) ? count.count : -1}
+                    rowsPerPage={rowsPerPage}
+                    page={page}
+                    onChangePage={handleChangePage}
+                    onChangeRowsPerPage={handleChangeRowsPerPage}
+                    className={classes.tableFooter}
+                    labelDisplayedRows={(d) => labelDisplayedRows({...d, countIsLoading: loadingCount})}
+                />
             </LoadingOverlayWrapper>
-            <TablePagination
-                rowsPerPageOptions={[5, 10, 25, 100]}
-                component="div"
-                count={count && isNonEmptyValue(count.count) ? count.count : -1}
-                rowsPerPage={rowsPerPage}
-                page={page}
-                onChangePage={handleChangePage}
-                onChangeRowsPerPage={handleChangeRowsPerPage}
-                className={classes.tableFooter}
-                labelDisplayedRows={(d) => labelDisplayedRows({...d, countIsLoading: loadingCount})}
-            />
         </Paper>
     );
 };


### PR DESCRIPTION
Prevents [VRE-1421](https://thehyve.atlassian.net/browse/VRE-1421)

I couldn't find a way to disable only the previous and next page buttons with TablePagination API of MUI.