### PR TITLE
Rewrite etag field in webdav responses for external storages.

### DIFF
--- a/projects/pluto/src/main/java/nl/fairspace/pluto/config/RoutingConfiguration.java
+++ b/projects/pluto/src/main/java/nl/fairspace/pluto/config/RoutingConfiguration.java
@@ -1,5 +1,6 @@
 package nl.fairspace.pluto.config;
 
+import nl.fairspace.pluto.config.dto.*;
 import org.springframework.cloud.commons.httpclient.ApacheHttpClientConnectionManagerFactory;
 import org.springframework.cloud.commons.httpclient.ApacheHttpClientFactory;
 import org.springframework.cloud.netflix.zuul.filters.ProxyRequestHelper;
@@ -19,7 +20,7 @@ public class RoutingConfiguration {
     }
 
     @Bean
-    public WebDAVPathRewritingFilter webDAVPathRewritingFilter(ZuulProperties zuulProperties) {
-        return new WebDAVPathRewritingFilter(zuulProperties);
+    public WebDAVPathRewritingFilter webDAVPathRewritingFilter(PlutoConfig plutoConfig, ZuulProperties zuulProperties) {
+        return new WebDAVPathRewritingFilter(plutoConfig, zuulProperties);
     }
 }

--- a/projects/pluto/src/main/java/nl/fairspace/pluto/config/WebDAVPathRewritingFilter.java
+++ b/projects/pluto/src/main/java/nl/fairspace/pluto/config/WebDAVPathRewritingFilter.java
@@ -4,6 +4,7 @@ import com.netflix.zuul.*;
 import com.netflix.zuul.context.*;
 import com.netflix.zuul.exception.*;
 import lombok.extern.slf4j.*;
+import nl.fairspace.pluto.config.dto.*;
 import org.springframework.cloud.netflix.zuul.filters.*;
 import org.springframework.http.*;
 import org.w3c.dom.*;
@@ -20,14 +21,18 @@ import java.io.*;
 import java.net.*;
 import java.util.regex.*;
 
+import static nl.fairspace.pluto.config.ExtendedHttpMethod.PROPFIND;
 import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.POST_TYPE;
 import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.SEND_RESPONSE_FILTER_ORDER;
+import static org.springframework.http.HttpStatus.*;
 
 @Slf4j
 public class WebDAVPathRewritingFilter extends ZuulFilter {
+    private final PlutoConfig plutoConfig;
     private final ZuulProperties zuulProperties;
 
-    public WebDAVPathRewritingFilter(ZuulProperties zuulProperties) {
+    public WebDAVPathRewritingFilter(PlutoConfig plutoConfig, ZuulProperties zuulProperties) {
+        this.plutoConfig = plutoConfig;
         this.zuulProperties = zuulProperties;
     }
 
@@ -44,25 +49,40 @@ public class WebDAVPathRewritingFilter extends ZuulFilter {
     @Override
     public boolean shouldFilter() {
         RequestContext ctx = RequestContext.getCurrentContext();
-        return ctx.getRequest().getMethod().equals("PROPFIND") &&
-                ctx.getRequest().getRequestURI().startsWith("/api/storages/");
+        return ctx.getRequest().getMethod().equalsIgnoreCase(PROPFIND.name()) &&
+                ctx.getRequest().getRequestURI().startsWith("/api/storages/") &&
+                valueOf(ctx.getResponseStatusCode()).is2xxSuccessful();
     }
 
     /**
      * Replace in DAV:multistatus -> DAV:response -> DAV:href
      * values of the form '/api/webdav/*' to '/api/storages/$storage/webdav/*'
      */
-    public void transform(InputStream in, String remotePrefix, String routePrefix, Writer writer) throws ParserConfigurationException, IOException, SAXException, XPathExpressionException, TransformerException {
+    public void transform(InputStream in,
+                          String remotePrefix, String routePrefix,
+                          String storageRootIri, String storageRoot,
+                          Writer writer) throws ParserConfigurationException, IOException, SAXException, XPathExpressionException, TransformerException {
         var documentBuilderFactory = DocumentBuilderFactory.newInstance();
         documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         var webDavResponse = documentBuilderFactory.newDocumentBuilder().parse(in);
         var xpath = XPathFactory.newInstance().newXPath();
-        var nodes = (NodeList) xpath.evaluate("/multistatus/response/href", webDavResponse, XPathConstants.NODESET);
-        for (int i=0; i < nodes.getLength(); i++) {
-            var node = nodes.item(i);
-            if (node.getTextContent() != null) {
-                node.setTextContent(node.getTextContent().replaceFirst(Pattern.quote(remotePrefix), routePrefix));
+        {
+            var nodes = (NodeList) xpath.evaluate("/multistatus/response/href", webDavResponse, XPathConstants.NODESET);
+            for (int i = 0; i < nodes.getLength(); i++) {
+                var node = nodes.item(i);
+                if (node.getTextContent() != null) {
+                    node.setTextContent(node.getTextContent().replaceFirst(Pattern.quote(remotePrefix), routePrefix));
+                }
+            }
+        }
+        if (storageRootIri != null) {
+            var nodes = (NodeList) xpath.evaluate("/multistatus/response/propstat/prop/getetag", webDavResponse, XPathConstants.NODESET);
+            for (int i = 0; i < nodes.getLength(); i++) {
+                var node = nodes.item(i);
+                if (node.getTextContent() != null) {
+                    node.setTextContent(node.getTextContent().replaceFirst(Pattern.quote(storageRootIri), storageRoot));
+                }
             }
         }
         var transformerFactory = TransformerFactory.newInstance();
@@ -79,7 +99,18 @@ public class WebDAVPathRewritingFilter extends ZuulFilter {
         if (parts.length < 5 || ! "webdav".equals(parts[4])) {
             throw new ZuulException("Not a Webdav endpoint", HttpStatus.METHOD_NOT_ALLOWED.value(), "Method not allowed.");
         }
-        String routePrefix = "/api/storages/%s/webdav".formatted(parts[3]);
+        var storageName = parts[3];
+        var storage = plutoConfig.getStorages().get(storageName);
+        if (storage == null) {
+            throw new ZuulException("Missing storage configuration", HttpStatus.BAD_GATEWAY.value(), "Missing storage configuration");
+        }
+        String routePrefix = "/api/storages/%s/webdav".formatted(storageName);
+        var storageRoot = "%s://%s:%s%s".formatted(
+                ctx.getRequest().getScheme(),
+                ctx.getRequest().getServerName(),
+                ctx.getRequest().getServerPort(),
+                routePrefix
+        );
         var route = zuulProperties.getRoutes().values().stream()
                 .filter(r -> r.getPath().startsWith(routePrefix))
                 .findFirst().orElseThrow(() -> new ZuulException("Invalid Webdav route", HttpStatus.NOT_FOUND.value(), "No such route configured"));
@@ -93,7 +124,7 @@ public class WebDAVPathRewritingFilter extends ZuulFilter {
         }
         var writer = new StringWriter();
         try {
-            transform(ctx.getResponseDataStream(), remotePrefix, routePrefix, writer);
+            transform(ctx.getResponseDataStream(), remotePrefix, routePrefix, storage.getRootDirectoryIri(), storageRoot, writer);
         } catch (Exception e) {
             log.error("Error translating webdav response", e);
             throw new ZuulException(e, HttpStatus.BAD_GATEWAY.value(), "Error translating webdav response");

--- a/projects/pluto/src/main/resources/application-local.yml
+++ b/projects/pluto/src/main/resources/application-local.yml
@@ -12,8 +12,8 @@ pluto:
        name: test
        label: Test
        url: /api/storages/test/webdav
-       searchUrl: /api/storages/test/search
-       rootDirectoryIri: http://localhost:8080/api/webdav
+       search-url: /api/storages/test/search
+       root-directory-iri: http://localhost:8080/api/webdav
 
 zuul:
   routes:

--- a/projects/pluto/src/test/java/nl/fairspace/pluto/config/WebDAVPathRewritingFilterTest.java
+++ b/projects/pluto/src/test/java/nl/fairspace/pluto/config/WebDAVPathRewritingFilterTest.java
@@ -1,5 +1,6 @@
 package nl.fairspace.pluto.config;
 
+import nl.fairspace.pluto.config.dto.*;
 import org.junit.*;
 import org.mockito.*;
 import org.springframework.cloud.netflix.zuul.filters.*;
@@ -12,19 +13,26 @@ public class WebDAVPathRewritingFilterTest {
     @Mock
     ZuulProperties zuulProperties;
 
-    private final WebDAVPathRewritingFilter filter = new WebDAVPathRewritingFilter(zuulProperties);
+    private final WebDAVPathRewritingFilter filter = new WebDAVPathRewritingFilter(null, zuulProperties);
 
     @Test
     public void transformWebdavResponse() throws Exception {
         var resource = getClass().getClassLoader().getResource("webdav_response.xml");
         var in = resource.openStream();
         var writer = new StringWriter();
-        filter.transform(in, "/api/webdav", "/api/storages/test/webdav", writer);
+        filter.transform(in,
+                "/api/webdav", "/api/storages/test/webdav",
+                "http://localhost:8080/api/webdav",
+                "http://localhost:9000/api/storages/test/webdav",
+                writer);
         writer.flush();
         System.err.println(writer.getBuffer().toString());
         var result = writer.getBuffer().toString();
         Assert.assertThat(result, stringContainsInOrder("<d:href>/api/storages/test/webdav/</d:href>"));
+        Assert.assertThat(result, stringContainsInOrder("<d:getetag>\"http://localhost:9000/api/storages/test/webdav\"</d:getetag>"));
         Assert.assertThat(result, stringContainsInOrder("<d:href>/api/storages/test/webdav/collection%202021-01-18_02_04-1/</d:href>"));
+        Assert.assertThat(result, stringContainsInOrder("<d:getetag>\"http://localhost:9000/api/storages/test/webdav/collection%202021-01-18_02_04-1\"</d:getetag>"));
         Assert.assertThat(result, stringContainsInOrder("<d:href>/api/storages/test/webdav/Book/</d:href>"));
+        Assert.assertThat(result, stringContainsInOrder("<d:getetag>\"http://localhost:9000/api/storages/test/webdav/Book\"</d:getetag>"));
     }
 }


### PR DESCRIPTION
Looks like for mounting the storages via webdav, at least using nautilus (the gnome file manager), also the etag field needs to be rewritten. That also solves the warnings in Jupyter that `/home/jovyan/test/webdav doesn't exist`.