### PR TITLE
Fix hidden properties filter logic.

### DIFF
--- a/projects/mercury/src/metadata/common/LinkedDataEntityForm.js
+++ b/projects/mercury/src/metadata/common/LinkedDataEntityForm.js
@@ -63,6 +63,7 @@ export const LinkedDataEntityForm = ({
     onAdd = () => {},
     onDelete = () => {},
     editable = true,
+    typeIri
 }) => {
     if (loading) {
         return <LoadingInlay />;
@@ -71,8 +72,6 @@ export const LinkedDataEntityForm = ({
     if (errorMessage !== '') {
         return <MessageDisplay message={errorMessage} />;
     }
-
-    const primaryType = values['@type'] && values['@type'][0] && values['@type'][0].id;
 
     return (
         <form
@@ -91,7 +90,7 @@ export const LinkedDataEntityForm = ({
                     properties
                         // Some properties are always hidden (e.g. @type) or hidden based on the type of entity (e.g. label for collection)
                         // Properties are also hidden when it is not editable and there is no value
-                        .filter(p => !shouldPropertyBeHidden(p.key, primaryType) && (p.isEditable || hasValue(values[p.key])))
+                        .filter(p => !shouldPropertyBeHidden(p.key, typeIri) && (p.isEditable || hasValue(values[p.key])))
 
                         // Properties are sorted based on the sh:order property, or by its label otherwise
                         .sort(comparing(
@@ -130,6 +129,7 @@ LinkedDataEntityForm.propTypes = {
     onDelete: PropTypes.func,
 
     errorMessage: PropTypes.string,
+    typeIri: PropTypes.string,
 
     loading: PropTypes.bool,
     properties: PropTypes.array,

--- a/projects/mercury/src/metadata/common/LinkedDataEntityFormContainer.js
+++ b/projects/mercury/src/metadata/common/LinkedDataEntityFormContainer.js
@@ -105,6 +105,7 @@ const LinkedDataEntityFormContainer = ({
                             onAdd={addValue}
                             onChange={updateValue}
                             onDelete={deleteValue}
+                            typeIri={typeInfo.typeIri}
                         />
                     </Grid>
                     {footer && <Grid item>{footer}</Grid>}

--- a/projects/mercury/src/metadata/common/NewLinkedDataEntityDialog.js
+++ b/projects/mercury/src/metadata/common/NewLinkedDataEntityDialog.js
@@ -89,6 +89,7 @@ const NewLinkedDataEntityDialog = ({shape, requireIdentifier = true, onClose, on
             <LinkedDataEntityForm
                 key="form"
                 id={formId}
+                typeIri={type}
                 onSubmit={createEntity}
                 properties={extendedProperties}
                 values={valuesWithUpdates}

--- a/projects/mercury/src/workspaces/WorkspaceInfo.js
+++ b/projects/mercury/src/workspaces/WorkspaceInfo.js
@@ -59,6 +59,7 @@ const WorkspaceInfo = (props: WorkspaceInfoProps) => {
                         loading={linkedDataLoading}
                         properties={properties}
                         values={values}
+                        typeIri={typeInfo.typeIri}
                     />
                 )}
             </Paper>


### PR DESCRIPTION
Fixes [VRE-1466](https://thehyve.atlassian.net/browse/VRE-1466)

Apparently the description and collection name were not meant to be a part of collection metadata panel, but the exclusion filter was broken (invalid type definition returning "undefined" type).
