### PR TITLE
[VRE-1474] Do not show basic authentication pop-up after session expires.

### DIFF
--- a/projects/saturn/src/main/java/io/fairspace/saturn/auth/SaturnKeycloakJettyAuthenticator.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/auth/SaturnKeycloakJettyAuthenticator.java
@@ -146,8 +146,9 @@ class SaturnKeycloakJettyAuthenticator extends KeycloakJettyAuthenticator {
                     return new AuthChallenge() {
                         @Override
                         public boolean challenge(HttpFacade exchange) {
-                            if (deployment.isEnableBasicAuth() && exchange.getRequest().getCookie("JSESSIONID") == null) {
-                                exchange.getResponse().addHeader("WWW-Authenticate", "Basic realm=\"Fairspace\"");
+                            if (deployment.isEnableBasicAuth() && exchange.getRequest().getCookie("JSESSIONID") == null
+                                    && !exchange.getRequest().getHeader("X-Requested-With").equals("XMLHttpRequest")) {
+                                exchange.getResponse().addHeader("WWW-Authenticate", "Basic");
                             }
                             exchange.getResponse().setStatus(getResponseCode());
                             return true;


### PR DESCRIPTION
[VRE-1474](https://thehyve.atlassian.net/browse/VRE-1474)

It seems that after long time the expired JSESSIONID cookie is not sent anymore and this is when Saturn used to send back the "WWW-Authenticate: Basic" header causing the authentication pop-up to show up, although I had difficulties reproducing the issue, even when playing with session timeout settings.  