### PR TITLE
Do not serve the dev UI via Pluto.

### DIFF
--- a/projects/pluto/src/main/resources/application-local.yml
+++ b/projects/pluto/src/main/resources/application-local.yml
@@ -30,9 +30,6 @@ zuul:
     saturn:
       path: /api/**
       url: http://localhost:8090/api/
-    ui:
-      path: /**
-      url: http://localhost:3000
 
   include-debug-header: true
 


### PR DESCRIPTION
Instead, pluto can serve the built UI directly and the dev UI can be reached directly at port 3000.