### PR TITLE
Add collection renaming warnig.

### DIFF
--- a/projects/mercury/src/collections/CollectionEditor.js
+++ b/projects/mercury/src/collections/CollectionEditor.js
@@ -43,6 +43,10 @@ const isNameValid = (name: string) => (
  */
 export const isInputValid = (properties: CollectionProperties) => isNameValid(properties.name);
 
+export const formatPrefix = (prefix: string) => (
+    prefix ? `[${prefix.replace(/[/\\]/, '')}] ` : ''
+);
+
 const styles = theme => ({
     textHelperBasic: {
         color: theme.palette.grey['600'],
@@ -86,10 +90,10 @@ export class CollectionEditor extends React.Component<CollectionEditorProps, Col
     state = {
         editing: true,
         saveInProgress: false,
-        properties: this.props.collection ?
-            copyProperties(this.props.collection) :
-            {
-                name: this.props.workspace.code ? `[${this.props.workspace.code.replace(/[/\\]/, '')}] ` : '',
+        properties: this.props.collection
+            ? copyProperties(this.props.collection)
+            : {
+                name: formatPrefix(this.props.workspace.code),
                 description: '',
                 ownerWorkspace: this.props.workspace.iri
             }
@@ -229,7 +233,10 @@ export class CollectionEditor extends React.Component<CollectionEditorProps, Col
                 <span className={this.validateNameStartsWithWorkspaceCode() ? this.props.classes.textHelperBasic : this.props.classes.textHelperWarning}>
                     <br />
                     {!this.validateNameStartsWithWorkspaceCode() && (
-                        <span><b>Warning!</b> Name does not start with the suggested form of workspace prefix!<br /></span>
+                        <span>
+                            <b>Warning!</b> Name does not start with the suggested form of a workspace code:
+                            <i> {formatPrefix(this.props.workspace.code)}</i><br />
+                        </span>
                     )}
                     Keep the workspace code prefix. It ensures collection uniqueness between workspaces.
                     <br />
@@ -253,7 +260,9 @@ export class CollectionEditor extends React.Component<CollectionEditorProps, Col
                 </DialogTitle>
                 <DialogContent>
                     {this.props.collection && (
-                        <DialogContentText>You can edit the collection details here.</DialogContentText>
+                        <DialogContentText>
+                            Be aware that renaming of a large collection can take more time.
+                        </DialogContentText>
                     )}
                     <TextField
                         autoFocus


### PR DESCRIPTION
Relates to [VRE-1513](https://thehyve.atlassian.net/browse/VRE-1513)
I added the warning as a part of edition dialog:
![Screenshot from 2021-08-06 11-56-55](https://user-images.githubusercontent.com/20908736/128493530-0c143ff8-ff51-470b-b110-ed7f7e48e784.png)

It could be also a separate confirmation popup, but this way might be less annoying for a user.
