### PR TITLE
Hide 'can query metadata' property on metadata page.

### DIFF
--- a/projects/mercury/src/constants.js
+++ b/projects/mercury/src/constants.js
@@ -102,6 +102,7 @@ export const CAN_MANAGE_URI = FAIRSPACE_NS + 'canManage';
 export const CAN_ADD_SHARED_METADATA_URI = FAIRSPACE_NS + 'canAddSharedMetadata';
 export const CAN_VIEW_PUBLIC_METADATA_URI = FAIRSPACE_NS + 'canViewPublicMetadata';
 export const CAN_VIEW_PUBLIC_DATA_URI = FAIRSPACE_NS + 'canViewPublicData';
+export const CAN_QUERY_METADATA_URI = FAIRSPACE_NS + 'canQueryMetadata';
 export const IS_ADMIN = FAIRSPACE_NS + 'isAdmin';
 export const IS_SUPERADMIN = FAIRSPACE_NS + 'isSuperadmin';
 export const IS_MEMBER_OF_URI = FAIRSPACE_NS + 'isMemberOf';

--- a/projects/mercury/src/metadata/common/metadataUtils.js
+++ b/projects/mercury/src/metadata/common/metadataUtils.js
@@ -119,6 +119,7 @@ export const shouldPropertyBeHidden = (key, domain) => {
         case consts.CAN_ADD_SHARED_METADATA_URI:
         case consts.CAN_VIEW_PUBLIC_METADATA_URI:
         case consts.CAN_VIEW_PUBLIC_DATA_URI:
+        case consts.CAN_QUERY_METADATA_URI:
         case consts.IS_ADMIN:
         case consts.IS_SUPERADMIN:
         case consts.IS_MEMBER_OF_URI:


### PR DESCRIPTION
A new permission (introduced due to [VRE-1483](https://thehyve.atlassian.net/browse/VRE-1483)) is shown in the user metadata page, which should not:

![User can query metadata](https://user-images.githubusercontent.com/7373499/130932319-78ac4d0d-506c-4402-ab01-5aa19811aa19.png)

This change hides this property on the metadata page.