### PR TITLE
Add secure headers for all resources.

### DIFF
--- a/projects/pluto/src/main/java/nl/fairspace/pluto/auth/filters/SecureResponseHeaderAppenderFilter.java
+++ b/projects/pluto/src/main/java/nl/fairspace/pluto/auth/filters/SecureResponseHeaderAppenderFilter.java
@@ -32,7 +32,7 @@ public class SecureResponseHeaderAppenderFilter implements Filter {
         httpServletResponse.setHeader("X-Permitted-Cross-Domain-Policies", "none");
         httpServletResponse.setHeader(
                 "Content-Security-Policy",
-                "default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; font-src 'self'; style-src: 'self'"
+                "default-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' 'unsafe-inline' https://*"
         );
         chain.doFilter(request, response);
     }

--- a/projects/pluto/src/main/java/nl/fairspace/pluto/auth/filters/SecureResponseHeaderAppenderFilter.java
+++ b/projects/pluto/src/main/java/nl/fairspace/pluto/auth/filters/SecureResponseHeaderAppenderFilter.java
@@ -1,0 +1,44 @@
+package nl.fairspace.pluto.auth.filters;
+
+import org.springframework.stereotype.Component;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * This filter adds secure headers to the response in order to increase the security of the application.
+ * Based on OWASP Secure Headers Project (https://owasp.org/www-project-secure-headers/).
+ *
+ * Relates to OWASP Top 10 2017, A6:2017-Security Misconfiguration
+ * (https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration)
+ *
+ * Headers already included by default: "Strict-Transport-Security"
+ */
+@Component
+public class SecureResponseHeaderAppenderFilter implements Filter {
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response,
+                         FilterChain chain) throws IOException, ServletException {
+        HttpServletResponse httpServletResponse = (HttpServletResponse) response;
+        httpServletResponse.setHeader("X-Frame-Options", "DENY");
+        httpServletResponse.setHeader("X-Content-Type-Options", "nosniff");
+        httpServletResponse.setHeader("X-XSS-Protection", "0");
+        httpServletResponse.setHeader("X-Permitted-Cross-Domain-Policies", "none");
+        httpServletResponse.setHeader(
+                "Content-Security-Policy",
+                "default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; font-src 'self'; style-src: 'self'"
+        );
+        chain.doFilter(request, response);
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+}

--- a/projects/pluto/src/main/resources/application.yml
+++ b/projects/pluto/src/main/resources/application.yml
@@ -92,6 +92,7 @@ zuul:
   - X-Frame-Options
   - X-Content-Type-Options
   - X-XSS-Protection
+  - X-Permitted-Cross-Domain-Policies
   - Origin  # Including the header would trigger CORS filtering downstream, but Pluto is already doing the filtering.
   set-content-length: true
   host:


### PR DESCRIPTION
Apply relevant headers to all responses, following [OWASP Secure Headers Project guides](https://www.owasp.org/index.php/OWASP_Secure_Headers_Project#tab=Headers).

Relates to [VRE-821](https://thehyve.atlassian.net/browse/VRE-821)

Remaining headers that were not added:

- `Strict-Transport-Security` - already added by default
- `Content-Security-Policy` - making strict policies here breaks the user interface, might be specific per installation

Headers that do not seem to bring any benefit (since we already have Pluto middle-layer with zuul taking care of filtering and routing rules):

- `Referrer-Policy`
- `Cross-Origin-Embedder-Policy`
- `Cross-Origin-Opener-Policy`
- `Cross-Origin-Resource-Policy`