### PR TITLE
Update workspace list on adding/removing workspace collections and users

### DIFF
--- a/projects/mercury/src/collections/CollectionsContext.js
+++ b/projects/mercury/src/collections/CollectionsContext.js
@@ -4,6 +4,7 @@ import CollectionAPI from "./CollectionAPI";
 import useAsync from "../common/hooks/UseAsync";
 import VocabularyContext from "../metadata/vocabulary/VocabularyContext";
 import UserContext from "../users/UserContext";
+import WorkspaceContext from "../workspaces/WorkspaceContext";
 
 const CollectionsContext = React.createContext({});
 
@@ -11,16 +12,17 @@ export const CollectionsProvider = ({children, collectionApi = CollectionAPI}) =
     const [showDeleted, setShowDeleted] = useState(false);
     const {vocabulary} = useContext(VocabularyContext);
     const {currentUser} = useContext(UserContext);
+    const {refreshWorkspaces} = useContext(WorkspaceContext);
 
     const {data: collections = [], error, loading, refresh} = useAsync(
         () => collectionApi.getCollections(showDeleted),
         [currentUser, showDeleted]
     );
 
-    const addCollection = (collection: CollectionProperties) => collectionApi.addCollection(collection, vocabulary).then(refresh);
+    const addCollection = (collection: CollectionProperties) => collectionApi.addCollection(collection, vocabulary).then(refresh).then(refreshWorkspaces);
     const updateCollection = (collection: Collection) => collectionApi.updateCollection(collection, vocabulary).then(refresh);
-    const deleteCollection = (collection: CollectionProperties) => collectionApi.deleteCollection(collection, showDeleted).then(refresh);
-    const undeleteCollection = (collection: CollectionProperties) => collectionApi.undeleteCollection(collection).then(refresh);
+    const deleteCollection = (collection: CollectionProperties) => collectionApi.deleteCollection(collection, showDeleted).then(refresh).then(refreshWorkspaces);
+    const undeleteCollection = (collection: CollectionProperties) => collectionApi.undeleteCollection(collection).then(refresh).then(refreshWorkspaces);
     const unpublish = (collection: CollectionProperties) => collectionApi.unpublish(collection).then(refresh);
     const renameCollection = (name: string, target: string) => collectionApi.renameCollection(name, target).then(refresh);
     const setPermission = (name: string, principal: string, access: AccessLevel) => collectionApi.setPermission(name, principal, access).then(refresh);

--- a/projects/mercury/src/workspaces/WorkspaceUserRolesContext.js
+++ b/projects/mercury/src/workspaces/WorkspaceUserRolesContext.js
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, {useContext} from 'react';
 import WorkspacesAPI from './WorkspacesAPI';
 import useAsync from "../common/hooks/UseAsync";
+import WorkspaceContext from "./WorkspaceContext";
 
 const WorkspaceUserRolesContext = React.createContext({});
 
@@ -12,8 +13,12 @@ export const WorkspaceUserRolesProvider = ({iri, children, workspacesAPI = Works
         refresh: refreshWorkspaceRoles
     } = useAsync(() => workspacesAPI.getWorkspaceRoles(iri), [iri]);
 
+    const {refreshWorkspaces} = useContext(WorkspaceContext);
+
     const setWorkspaceRole = (userIri: string, role: string) => (
-        workspacesAPI.setWorkspaceRole(iri, userIri, role).then(refreshWorkspaceRoles)
+        workspacesAPI.setWorkspaceRole(iri, userIri, role)
+            .then(refreshWorkspaceRoles)
+            .then(refreshWorkspaces)
     );
 
     return (


### PR DESCRIPTION
Columns related to number of collections and workspace users of the workspaces list were not updated on updating workspace users and collections. This is because workspaces refresh was triggered only on adding/removing workspaces or updating their details.
This caused an issue with 'Delete workspace' button: see [VRE-1530](https://thehyve.atlassian.net/browse/VRE-1530).

I added triggering extra refresh of workspaces list on all the actions mentioned above, since workspaces refresh is not a heavy call, so it should not have a big impact on performance.