### PR TITLE
Upgrade Milton to v3.0.1.269, improve unauthorized error handling.

### DIFF
--- a/projects/saturn/build.gradle
+++ b/projects/saturn/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         jena_version = '4.1.0'
-        milton_version = '2.8.0.3'
+        milton_version = '3.0.1.269'
         mockitoVersion = '3.6.28'
         jacksonVersion = '2.11.3' // check what version is used by Jena
         postgresqlVersion = '42.2.18'

--- a/projects/saturn/src/main/java/io/fairspace/saturn/webdav/BaseResource.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/webdav/BaseResource.java
@@ -30,6 +30,7 @@ import static io.fairspace.saturn.vocabulary.Vocabularies.USER_VOCABULARY;
 import static io.fairspace.saturn.webdav.DavFactory.childSubject;
 import static io.fairspace.saturn.webdav.WebDAVServlet.includeMetadataLinks;
 import static io.fairspace.saturn.webdav.WebDAVServlet.timestampLiteral;
+import static io.milton.http.ResponseStatus.SC_FORBIDDEN;
 import static io.milton.property.PropertySource.PropertyAccessibility.READ_ONLY;
 import static io.milton.property.PropertySource.PropertyAccessibility.WRITABLE;
 import static java.util.stream.Collectors.toList;
@@ -104,7 +105,7 @@ abstract class BaseResource implements PropFindableResource, DeletableResource, 
     protected void delete(boolean purge) throws NotAuthorizedException, ConflictException, BadRequestException {
         if (purge) {
             if (!factory.userService.currentUser().isAdmin()) {
-                throw new NotAuthorizedException();
+                throw new NotAuthorizedException("Not authorized to purge the resource.", this, SC_FORBIDDEN);
             }
             subject.getModel().removeAll(subject, null, null).removeAll(null, null, subject);
         } else if (!subject.hasProperty(FS.dateDeleted)) {
@@ -190,7 +191,7 @@ abstract class BaseResource implements PropFindableResource, DeletableResource, 
     public void copyTo(io.milton.resource.CollectionResource parent, String name)
             throws NotAuthorizedException, BadRequestException, ConflictException {
         if (!((DirectoryResource) parent).access.canWrite()) {
-            throw new NotAuthorizedException(this);
+            throw new NotAuthorizedException("Not authorized to copy this resource.", this, SC_FORBIDDEN);
         }
         if (name != null) {
             name = name.trim();
@@ -378,7 +379,7 @@ abstract class BaseResource implements PropFindableResource, DeletableResource, 
 
     protected void undelete() throws BadRequestException, NotAuthorizedException, ConflictException {
         if (!canUndelete()) {
-            throw new NotAuthorizedException(this);
+            throw new NotAuthorizedException("Not authorized to undelete this resource.", this, SC_FORBIDDEN);
         }
         if (!subject.hasProperty(FS.dateDeleted)) {
             throw new ConflictException(this, "Cannot restore");

--- a/projects/saturn/src/main/java/io/fairspace/saturn/webdav/CollectionResource.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/webdav/CollectionResource.java
@@ -19,6 +19,7 @@ import java.util.Set;
 
 import static io.fairspace.saturn.rdf.ModelUtils.getStringProperty;
 import static io.fairspace.saturn.webdav.DavFactory.getGrantedPermission;
+import static io.milton.http.ResponseStatus.SC_FORBIDDEN;
 import static java.util.stream.Collectors.joining;
 
 class CollectionResource extends DirectoryResource {
@@ -39,7 +40,7 @@ class CollectionResource extends DirectoryResource {
     @Override
     public void moveTo(io.milton.resource.CollectionResource rDest, String name) throws ConflictException, NotAuthorizedException, BadRequestException {
         if (!canManage()) {
-            throw new NotAuthorizedException(this);
+            throw new NotAuthorizedException("Not authorized to copy the resource.", this, SC_FORBIDDEN);
         }
         if (!(rDest instanceof RootResource)) {
             throw new BadRequestException(this, "Cannot move a collection to a non-root folder.");
@@ -80,7 +81,7 @@ class CollectionResource extends DirectoryResource {
 
     public void setOwnedBy(Resource owner) throws NotAuthorizedException, BadRequestException {
         if (!canManage()) {
-            throw new NotAuthorizedException(this);
+            throw new NotAuthorizedException("Not authorized to set the resource owner.", this, SC_FORBIDDEN);
         }
         if (!owner.hasProperty(RDF.type, FS.Workspace)) {
             throw new BadRequestException(this, "Invalid owner");
@@ -284,7 +285,7 @@ class CollectionResource extends DirectoryResource {
 
     private void setStatus(Status status) throws NotAuthorizedException, ConflictException {
         if (!canManage()) {
-            throw new NotAuthorizedException(this);
+            throw new NotAuthorizedException("Not authorized to change the status of this resource.", this, SC_FORBIDDEN);
         }
         if (!availableStatuses().contains(status)) {
             throw new ConflictException(this);
@@ -299,7 +300,7 @@ class CollectionResource extends DirectoryResource {
 
     private void setAccessMode(AccessMode mode) throws NotAuthorizedException, ConflictException {
         if (!canManage()) {
-            throw new NotAuthorizedException(this);
+            throw new NotAuthorizedException("Not authorized to change the access mode of this resource.", this, SC_FORBIDDEN);
         }
         if (!availableAccessModes().contains(mode)) {
             throw new ConflictException(this);
@@ -309,7 +310,7 @@ class CollectionResource extends DirectoryResource {
 
     private void setPermission(Resource principal, Access grantedAccess) throws BadRequestException, NotAuthorizedException {
         if (!canManage()) {
-            throw new NotAuthorizedException(this);
+            throw new NotAuthorizedException("Not authorized to change permissions on this resource.", this, SC_FORBIDDEN);
         }
         if (principal.hasProperty(RDF.type, FS.User)) {
             if (grantedAccess == Access.Write || grantedAccess == Access.Manage) {
@@ -351,7 +352,7 @@ class CollectionResource extends DirectoryResource {
 
     private void unpublish() throws NotAuthorizedException, ConflictException {
         if (!factory.userService.currentUser().isAdmin()) {
-            throw new NotAuthorizedException(this);
+            throw new NotAuthorizedException("Not authorized to unpublish this resource.", this, SC_FORBIDDEN);
         }
         if (getAccessMode() != AccessMode.DataPublished) {
             throw new ConflictException(this, "Cannot unpublish collection that is not published.");

--- a/projects/saturn/src/main/java/io/fairspace/saturn/webdav/FileResource.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/webdav/FileResource.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import static io.fairspace.saturn.rdf.ModelUtils.*;
 import static io.fairspace.saturn.webdav.WebDAVServlet.fileVersion;
 import static io.fairspace.saturn.webdav.WebDAVServlet.getBlob;
+import static io.milton.http.ResponseStatus.SC_FORBIDDEN;
 import static java.lang.Integer.parseInt;
 
 class FileResource extends BaseResource implements io.milton.resource.FileResource, ReplaceableResource {
@@ -132,7 +133,7 @@ class FileResource extends BaseResource implements io.milton.resource.FileResour
 
     private void revert(String versionStr) throws BadRequestException, NotAuthorizedException, ConflictException {
         if (!access.canWrite()) {
-            throw new NotAuthorizedException(this);
+            throw new NotAuthorizedException("Not authorized to revert this resource to a previous version.", this, SC_FORBIDDEN);
         }
 
         int version;

--- a/projects/saturn/src/main/java/io/fairspace/saturn/webdav/RootResource.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/webdav/RootResource.java
@@ -25,6 +25,7 @@ import static io.fairspace.saturn.webdav.DavFactory.childSubject;
 import static io.fairspace.saturn.webdav.PathUtils.validateCollectionName;
 import static io.fairspace.saturn.webdav.WebDAVServlet.owner;
 import static io.fairspace.saturn.webdav.WebDAVServlet.timestampLiteral;
+import static io.milton.http.ResponseStatus.SC_FORBIDDEN;
 
 @Log4j2
 class RootResource implements io.milton.resource.CollectionResource, MakeCollectionableResource, PropFindableResource {
@@ -120,7 +121,7 @@ class RootResource implements io.milton.resource.CollectionResource, MakeCollect
         if (!factory.currentUserResource().hasProperty(FS.isMemberOf, ws)
                 && !factory.currentUserResource().hasProperty(FS.isManagerOf, ws)
                 && !factory.userService.currentUser().isAdmin()) {
-            throw new NotAuthorizedException();
+            throw new NotAuthorizedException("Not authorized to create a new collection in this workspace.", this, SC_FORBIDDEN);
         }
 
         subj.addProperty(FS.ownedBy, ws).addProperty(FS.belongsTo, ws);

--- a/projects/saturn/src/test/java/io/fairspace/saturn/webdav/DavFactoryTest.java
+++ b/projects/saturn/src/test/java/io/fairspace/saturn/webdav/DavFactoryTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 
 import static io.fairspace.saturn.TestUtils.*;
 import static io.fairspace.saturn.auth.RequestContext.getCurrentRequest;
+import static io.milton.http.ResponseStatus.SC_FORBIDDEN;
 import static java.lang.String.format;
 import static org.apache.jena.query.DatasetFactory.createTxnMem;
 import static org.apache.jena.rdf.model.ResourceFactory.createResource;
@@ -394,6 +395,8 @@ public class DavFactoryTest {
             fail("Only admin can purge a collection.");
         } catch (NotAuthorizedException e) {
             assertNotNull(e);
+            assertEquals(SC_FORBIDDEN, e.getRequiredStatusCode());
+            assertEquals("Not authorized to purge the resource.", e.getMessage());
         }
 
         userService.currentUser().setAdmin(true);


### PR DESCRIPTION
Major version upgrade (2.8 -> 3.0).

I did not find any possible issues or a tutorial from Milton, as for 1.8 to 2.x migration, indicating major changes.
Overview of the changes in Milton: https://milton.io/download/release_history/

This PR includes also a fix for `NotAuthorizedException` handling -> throwing `403`, instead of `401` (see [new error handling in Milton](https://github.com/miltonio/milton2/blob/master/milton-server-ce/src/main/java/io/milton/http/StandardFilter.java#L68)).
Fixes [VRE-1532](https://thehyve.atlassian.net/browse/VRE-1532)