### PR TITLE
Fix header of external storage webdav response after rewriting.

### DIFF
--- a/projects/pluto/src/main/java/nl/fairspace/pluto/config/WebDAVPathRewritingFilter.java
+++ b/projects/pluto/src/main/java/nl/fairspace/pluto/config/WebDAVPathRewritingFilter.java
@@ -129,7 +129,9 @@ public class WebDAVPathRewritingFilter extends ZuulFilter {
             log.error("Error translating webdav response", e);
             throw new ZuulException(e, HttpStatus.BAD_GATEWAY.value(), "Error translating webdav response");
         }
-        ctx.setResponseBody(writer.toString());
+        var content = writer.toString();
+        ctx.setResponseBody(content);
+        ctx.setOriginContentLength(Long.valueOf(content.length()));
         ctx.setResponseDataStream(null);
         return null;
     }


### PR DESCRIPTION
Fixes [VRE-1542](https://thehyve.atlassian.net/browse/VRE-1542)

I suspect the issue is related with the upgrade to Milton>3.0 - something slightly changed in the webdav response headers, i.e. content-length:

>  v3.0.0.93
January 21, 2021
...
    PROPFIND response with Depth: 0 header now provides file content length.

(source: https://milton.io/download/release_history/)

It did not cause any issues for Fairspace internal resources (Fairspace test plan was executed successfully), there is only one issue when fetching external storage collection.
The issue is `ERR_CONTENT_LENGTH_MISMATCH` shown in the browser after receiving response from Pluto, see: https://fairspace.ci.fairway.app/external-storages/test

It looks like it was caused by the path rewriting logic - original content length was returned in the header, while the content length might have been changed after rewriting.  