### PR TITLE
Fx content-length header calculation for external storages.

### DIFF
--- a/projects/pluto/src/main/java/nl/fairspace/pluto/config/WebDAVPathRewritingFilter.java
+++ b/projects/pluto/src/main/java/nl/fairspace/pluto/config/WebDAVPathRewritingFilter.java
@@ -19,6 +19,7 @@ import javax.xml.xpath.*;
 
 import java.io.*;
 import java.net.*;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.*;
 
 import static nl.fairspace.pluto.config.ExtendedHttpMethod.PROPFIND;
@@ -131,7 +132,7 @@ public class WebDAVPathRewritingFilter extends ZuulFilter {
         }
         var content = writer.toString();
         ctx.setResponseBody(content);
-        ctx.setOriginContentLength(Long.valueOf(content.length()));
+        ctx.setOriginContentLength(Long.valueOf(content.getBytes(StandardCharsets.UTF_8).length));
         ctx.setResponseDataStream(null);
         return null;
     }


### PR DESCRIPTION
The previous solution was not working correctly for some characters, setting the content length to shorter than actual. This caused cutting of some of the last characters in the response body, e.g. closing xml tags (making xml content invalid).