### PR TITLE
prevent double scroll when table exeeds max height

### DIFF
--- a/projects/mercury/src/metadata/views/MetadataView.styles.js
+++ b/projects/mercury/src/metadata/views/MetadataView.styles.js
@@ -23,6 +23,7 @@ const styles = theme => ({
         marginTop: 10,
         overflowX: 'auto',
         width: '100%',
+        overflowY: 'hidden',
         maxHeight: 'calc(100vh - 210px)',
     },
     clearAllButtonContainer: {

--- a/projects/mercury/src/metadata/views/MetadataView.styles.js
+++ b/projects/mercury/src/metadata/views/MetadataView.styles.js
@@ -1,5 +1,3 @@
-import * as consts from "../../constants";
-
 const CENTRAL_PANEL_WIDTH = '70%';
 const RIGHT_PANEL_WIDTH = '30%';
 
@@ -13,7 +11,7 @@ const styles = theme => ({
     },
     centralPanel: {
         width: CENTRAL_PANEL_WIDTH,
-        overflowX: 'auto',
+        overflowX: 'auto'
     },
     centralPanelFullWidth: {
         width: '100%'
@@ -25,8 +23,7 @@ const styles = theme => ({
         marginTop: 10,
         overflowX: 'auto',
         width: '100%',
-        overflowY: 'hidden',
-        maxHeight: consts.MAIN_CONTENT_MAX_HEIGHT,
+        maxHeight: 'calc(100vh - 210px)',
     },
     clearAllButtonContainer: {
         textAlign: 'end'

--- a/projects/mercury/src/metadata/views/MetadataViewTable.js
+++ b/projects/mercury/src/metadata/views/MetadataViewTable.js
@@ -15,6 +15,7 @@ import ColumnFilterInput from "../../common/components/ColumnFilterInput";
 
 type MetadataViewTableProperties = {
     data: MetadataViewData;
+    loading: boolean;
     columns: MetadataViewColumn[];
     visibleColumnNames: string[];
     idColumn: MetadataViewColumn;

--- a/projects/mercury/src/metadata/views/MetadataViewTable.js
+++ b/projects/mercury/src/metadata/views/MetadataViewTable.js
@@ -15,7 +15,6 @@ import ColumnFilterInput from "../../common/components/ColumnFilterInput";
 
 type MetadataViewTableProperties = {
     data: MetadataViewData;
-    loading: boolean;
     columns: MetadataViewColumn[];
     visibleColumnNames: string[];
     idColumn: MetadataViewColumn;
@@ -48,7 +47,7 @@ const CUSTOM_RESOURCE_COLUMNS = ['access', 'path'];
 const RESOURCE_TYPE_COLUMN = `${RESOURCES_VIEW}_type`;
 
 export const MetadataViewTable = (props: MetadataViewTableProperties) => {
-    const {columns, visibleColumnNames, loading, data, toggleRow, selected, view, idColumn, history, collections} = props;
+    const {columns, visibleColumnNames, data, toggleRow, selected, view, idColumn, history, collections} = props;
     const classes = useStyles();
     const {textFiltersObject, setTextFiltersObject} = props;
     const visibleColumns = columns.filter(column => visibleColumnNames.includes(column.name));
@@ -184,7 +183,7 @@ export const MetadataViewTable = (props: MetadataViewTableProperties) => {
     const rowCount = data && data.rows && data.rows.length;
 
     return (
-        <Table data-testid="results-table" size="small" stickyHeader={!loading}>
+        <Table data-testid="results-table" size="small" stickyHeader>
             <TableHead>
                 <TableRow>
                     <TableCell style={{padding: 0}}>

--- a/projects/mercury/src/metadata/views/MetadataViewTable.js
+++ b/projects/mercury/src/metadata/views/MetadataViewTable.js
@@ -47,7 +47,7 @@ const CUSTOM_RESOURCE_COLUMNS = ['access', 'path'];
 const RESOURCE_TYPE_COLUMN = `${RESOURCES_VIEW}_type`;
 
 export const MetadataViewTable = (props: MetadataViewTableProperties) => {
-    const {columns, visibleColumnNames, data, toggleRow, selected, view, idColumn, history, collections} = props;
+    const {columns, visibleColumnNames, loading, data, toggleRow, selected, view, idColumn, history, collections} = props;
     const classes = useStyles();
     const {textFiltersObject, setTextFiltersObject} = props;
     const visibleColumns = columns.filter(column => visibleColumnNames.includes(column.name));
@@ -183,7 +183,7 @@ export const MetadataViewTable = (props: MetadataViewTableProperties) => {
     const rowCount = data && data.rows && data.rows.length;
 
     return (
-        <Table data-testid="results-table" size="small" stickyHeader>
+        <Table data-testid="results-table" size="small" stickyHeader={!loading}>
             <TableHead>
                 <TableRow>
                     <TableCell style={{padding: 0}}>

--- a/projects/mercury/src/metadata/views/MetadataViewTableContainer.js
+++ b/projects/mercury/src/metadata/views/MetadataViewTableContainer.js
@@ -69,7 +69,7 @@ const styles = () => ({
     },
     tableContents: {
         "minHeight": '200px',
-        "maxHeight": 'calc(100vh - 270px)',
+        "maxHeight": 'calc(100vh - 310px)',
         "overflowY": 'auto',
         "overflowX": 'auto',
         '& .MuiTableCell-stickyHeader': {


### PR DESCRIPTION
Table paging controls were not visible for large tables, especially when filters are active. Fixed by styling finetune