### PR TITLE
Fix folder upload issue

### DIFF
--- a/projects/mercury/src/file/FileBrowser.js
+++ b/projects/mercury/src/file/FileBrowser.js
@@ -108,7 +108,7 @@ export const FileBrowser = (props: FileBrowserProperties) => {
     const [overwriteFolderCandidateNames, setOverwriteFolderCandidateNames] = useState([]);
     const [currentUpload, setCurrentUpload] = useState({});
 
-    const InitializeDropzone = () => useDropzone({
+    const useFairspaceDropzone = () => useDropzone({
         noClick: true,
         noKeyboard: true,
         multiple: true,
@@ -137,8 +137,8 @@ export const FileBrowser = (props: FileBrowserProperties) => {
         }
     });
 
-    const fileDropzoneProperties = InitializeDropzone();
-    const folderDropzoneProperties = InitializeDropzone();
+    const fileDropzoneProperties = useFairspaceDropzone();
+    const folderDropzoneProperties = useFairspaceDropzone();
 
     // Deselect all files on history changes
     useEffect(() => {

--- a/projects/mercury/src/file/FileBrowser.js
+++ b/projects/mercury/src/file/FileBrowser.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import React, {useContext, useEffect, useRef, useState} from 'react';
 import {withRouter} from "react-router-dom";
 import {useDropzone} from "react-dropzone";
@@ -109,38 +108,39 @@ export const FileBrowser = (props: FileBrowserProperties) => {
     const [overwriteFolderCandidateNames, setOverwriteFolderCandidateNames] = useState([]);
     const [currentUpload, setCurrentUpload] = useState({});
 
-    function initializeDropzone() {
+    function InitializeDropzone() {
         return useDropzone({
-        noClick: true,
-        noKeyboard: true,
-        multiple: true,
-        useFsAccessApi: false,
-        onDropAccepted: (droppedFiles) => {
-            const newUpload = {
-                id: generateUuid(),
-                files: droppedFiles,
-                destinationPath: openedPath,
-            };
-            const newOverwriteFolderCandidates = getConflictingFolders(droppedFiles, existingFolderNames);
-            const newOverwriteFileCandidates = getConflictingFiles(droppedFiles, existingFileNames);
+            noClick: true,
+            noKeyboard: true,
+            multiple: true,
+            useFsAccessApi: false,
+            onDropAccepted: (droppedFiles) => {
+                const newUpload = {
+                    id: generateUuid(),
+                    files: droppedFiles,
+                    destinationPath: openedPath,
+                };
+                const newOverwriteFolderCandidates = getConflictingFolders(droppedFiles, existingFolderNames);
+                const newOverwriteFileCandidates = getConflictingFiles(droppedFiles, existingFileNames);
 
-            if (newOverwriteFileCandidates.length > 0 || newOverwriteFolderCandidates.length > 0) {
-                setOverwriteFileCandidateNames(newOverwriteFileCandidates);
-                setOverwriteFolderCandidateNames(newOverwriteFolderCandidates);
-                if (isOverwriteCandidateDeleted([...newOverwriteFileCandidates, ...newOverwriteFolderCandidates])) {
-                    setShowCannotOverwriteWarning(true);
-                    return;
+                if (newOverwriteFileCandidates.length > 0 || newOverwriteFolderCandidates.length > 0) {
+                    setOverwriteFileCandidateNames(newOverwriteFileCandidates);
+                    setOverwriteFolderCandidateNames(newOverwriteFolderCandidates);
+                    if (isOverwriteCandidateDeleted([...newOverwriteFileCandidates, ...newOverwriteFolderCandidates])) {
+                        setShowCannotOverwriteWarning(true);
+                        return;
+                    }
+                    setCurrentUpload(newUpload);
+                    setShowOverwriteConfirmation(true);
+                } else {
+                    startUpload(newUpload).then(refreshFiles);
                 }
-                setCurrentUpload(newUpload);
-                setShowOverwriteConfirmation(true);
-            } else {
-                startUpload(newUpload).then(refreshFiles);
             }
-        }
-    })};
+        });
+    }
 
-    const fileDropzoneProperties = initializeDropzone();
-    const folderDropzoneProperties = initializeDropzone();
+    const fileDropzoneProperties = InitializeDropzone();
+    const folderDropzoneProperties = InitializeDropzone();
 
     // Deselect all files on history changes
     useEffect(() => {
@@ -182,7 +182,7 @@ export const FileBrowser = (props: FileBrowserProperties) => {
     }
 
     const uploadFolder = () => {
-        folderDropzoneProperties.open()
+        folderDropzoneProperties.open();
     };
 
     const uploadFile = () => {
@@ -286,8 +286,8 @@ export const FileBrowser = (props: FileBrowserProperties) => {
                 {...fileDropzoneProperties.getRootProps()}
                 className={`${classes.dropzone} ${fileDropzoneProperties.isDragActive && classes.activeStyle} ${fileDropzoneProperties.isDragAccept && classes.acceptStyle} ${fileDropzoneProperties.isDragReject && classes.rejectStyle}`}
             >
-                <input {...fileDropzoneProperties.getInputProps({ webkitdirectory: undefined })} />
-                <input {...folderDropzoneProperties.getInputProps({ webkitdirectory: "" })} />
+                <input {...fileDropzoneProperties.getInputProps({webkitdirectory: undefined})} />
+                <input {...folderDropzoneProperties.getInputProps({webkitdirectory: ""})} />
                 <FileList
                     selectionEnabled={openedCollection.canRead}
                     files={files.map(item => ({...item, selected: selection.isSelected(item.filename)}))}

--- a/projects/mercury/src/file/FileBrowser.js
+++ b/projects/mercury/src/file/FileBrowser.js
@@ -108,36 +108,34 @@ export const FileBrowser = (props: FileBrowserProperties) => {
     const [overwriteFolderCandidateNames, setOverwriteFolderCandidateNames] = useState([]);
     const [currentUpload, setCurrentUpload] = useState({});
 
-    function InitializeDropzone() {
-        return useDropzone({
-            noClick: true,
-            noKeyboard: true,
-            multiple: true,
-            useFsAccessApi: false,
-            onDropAccepted: (droppedFiles) => {
-                const newUpload = {
-                    id: generateUuid(),
-                    files: droppedFiles,
-                    destinationPath: openedPath,
-                };
-                const newOverwriteFolderCandidates = getConflictingFolders(droppedFiles, existingFolderNames);
-                const newOverwriteFileCandidates = getConflictingFiles(droppedFiles, existingFileNames);
+    const InitializeDropzone = () => useDropzone({
+        noClick: true,
+        noKeyboard: true,
+        multiple: true,
+        useFsAccessApi: false,
+        onDropAccepted: (droppedFiles) => {
+            const newUpload = {
+                id: generateUuid(),
+                files: droppedFiles,
+                destinationPath: openedPath,
+            };
+            const newOverwriteFolderCandidates = getConflictingFolders(droppedFiles, existingFolderNames);
+            const newOverwriteFileCandidates = getConflictingFiles(droppedFiles, existingFileNames);
 
-                if (newOverwriteFileCandidates.length > 0 || newOverwriteFolderCandidates.length > 0) {
-                    setOverwriteFileCandidateNames(newOverwriteFileCandidates);
-                    setOverwriteFolderCandidateNames(newOverwriteFolderCandidates);
-                    if (isOverwriteCandidateDeleted([...newOverwriteFileCandidates, ...newOverwriteFolderCandidates])) {
-                        setShowCannotOverwriteWarning(true);
-                        return;
-                    }
-                    setCurrentUpload(newUpload);
-                    setShowOverwriteConfirmation(true);
-                } else {
-                    startUpload(newUpload).then(refreshFiles);
+            if (newOverwriteFileCandidates.length > 0 || newOverwriteFolderCandidates.length > 0) {
+                setOverwriteFileCandidateNames(newOverwriteFileCandidates);
+                setOverwriteFolderCandidateNames(newOverwriteFolderCandidates);
+                if (isOverwriteCandidateDeleted([...newOverwriteFileCandidates, ...newOverwriteFolderCandidates])) {
+                    setShowCannotOverwriteWarning(true);
+                    return;
                 }
+                setCurrentUpload(newUpload);
+                setShowOverwriteConfirmation(true);
+            } else {
+                startUpload(newUpload).then(refreshFiles);
             }
-        });
-    }
+        }
+    });
 
     const fileDropzoneProperties = InitializeDropzone();
     const folderDropzoneProperties = InitializeDropzone();
@@ -286,6 +284,8 @@ export const FileBrowser = (props: FileBrowserProperties) => {
                 {...fileDropzoneProperties.getRootProps()}
                 className={`${classes.dropzone} ${fileDropzoneProperties.isDragActive && classes.activeStyle} ${fileDropzoneProperties.isDragAccept && classes.acceptStyle} ${fileDropzoneProperties.isDragReject && classes.rejectStyle}`}
             >
+                {/* Since dropzone doesn't support a native folder picker we need to create an input element for both folders and files
+                https://github.com/react-dropzone/react-dropzone/discussions/1157 */}
                 <input {...fileDropzoneProperties.getInputProps({webkitdirectory: undefined})} />
                 <input {...folderDropzoneProperties.getInputProps({webkitdirectory: ""})} />
                 <FileList


### PR DESCRIPTION
We use the react-dropzone component. 

It doesn't support a folder dialog out of the box, only a workaround with input element see https://github.com/react-dropzone/react-dropzone/discussions/1157

In the existing solution a variable 'isFolderUpload' was used. The problem with this was the input element was already rendered, this caused a delay of 1 click. So if you click 'upload folder' you see a file dialog, click 'upload folder' again, now it is a folder dialog, because the variable was set by the previous click, and the second rendering uses this value. 

Previous solution tried to overcome this with this:
```

    // A hook to make sure that isFolderUpload state is changed before opening the upload dialog
    useEffect(() => {
        if (isFolderUpload !== undefined) {
            open();
        }
    }, [isFolderUpload, open]);
```
In Chrome and Edge this causes infinite re-rendering. Firefox blocks it. 

Solution for now is to remove the useEffect, en render two input elements, one for folders one for files.
