### PR TITLE
Add spring cloud gateway configuration fixes

### DIFF
--- a/projects/pluto/src/main/resources/application.yml
+++ b/projects/pluto/src/main/resources/application.yml
@@ -33,9 +33,16 @@ spring:
       default-filters:
       - RemoveRequestHeader=Pragma X-Frame-Options X-Content-Type-Options X-XSS-Protection X-Permitted-Cross-Domain-Policies Origin
         # Including the ORIGIN header would trigger CORS filtering downstream, but Pluto is already doing the filtering.
+      - name: Retry
+        args:
+          methods: GET,PUT,POST,DELETE
+          exceptions:
+            - reactor.netty.http.client.PrematureCloseException
       httpclient:
         connect-timeout: 2000
         response-timeout: 600s
+        pool:
+          max-idle-time: 20s
       x-forwarded:
         port-enabled: false
         host-enabled: false

--- a/projects/pluto/src/main/resources/application.yml
+++ b/projects/pluto/src/main/resources/application.yml
@@ -36,6 +36,16 @@ spring:
       httpclient:
         connect-timeout: 2000
         response-timeout: 600s
+      x-forwarded:
+        port-enabled: false
+        host-enabled: false
+        proto-enabled: false
+        prefix-enabled: false
+        port-append: false
+        host-append: false
+        proto-append: false
+        prefix-append: false
+        enabled: false
 
 management:
   endpoint:


### PR DESCRIPTION
[Fix Keycloak returning secure header related error.](https://github.com/thehyve/fairspace/commit/567f97a633738e352d000bf0924bfd3f607e6032) - This is an equivalent of `add-proxy-headers: false` setting we had
before for Zuul.

[Fix "Connection prematurely closed BEFORE response" error.](https://github.com/thehyve/fairspace/commit/276f32264dc89e424914239f2280938c1b1ebf21) - Fix based on
https://github.com/spring-cloud/spring-cloud-gateway/issues/2046#issuecomment-1561019873