### PR TITLE
Prevent var usage by Lombok

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -310,7 +310,7 @@ tags
 [._]*.un~
 
 ### VisualStudioCode ###
-.vscode/*
+.vscode
 
 ### VisualStudioCode Patch ###
 # Ignore all local history of files

--- a/projects/saturn/src/main/java/io/fairspace/saturn/services/views/ViewService.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/services/views/ViewService.java
@@ -2,7 +2,7 @@ package io.fairspace.saturn.services.views;
 
 import io.fairspace.saturn.config.*;
 import io.fairspace.saturn.vocabulary.FS;
-import lombok.*;
+import lombok.SneakyThrows;
 import lombok.extern.log4j.*;
 import org.apache.jena.datatypes.xsd.*;
 import org.apache.jena.query.*;

--- a/projects/saturn/src/main/java/io/fairspace/saturn/services/views/ViewStoreClient.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/services/views/ViewStoreClient.java
@@ -3,7 +3,7 @@ package io.fairspace.saturn.services.views;
 import io.fairspace.saturn.config.*;
 import io.fairspace.saturn.config.ViewsConfig.*;
 import io.fairspace.saturn.services.views.Table.*;
-import lombok.*;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.*;
 import org.apache.commons.lang3.tuple.*;
 

--- a/projects/saturn/src/main/java/io/fairspace/saturn/services/views/ViewStoreClientFactory.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/services/views/ViewStoreClientFactory.java
@@ -6,7 +6,8 @@ import com.zaxxer.hikari.*;
 import io.fairspace.saturn.config.*;
 import io.fairspace.saturn.config.ViewsConfig.*;
 import io.fairspace.saturn.vocabulary.*;
-import lombok.*;
+import lombok.Builder;
+import lombok.Data;
 import lombok.extern.slf4j.*;
 
 import javax.sql.*;


### PR DESCRIPTION
No longer do an import of lombok.*, since this also imports 'var' and overrides native Java keyword. Intellij can handle this, but VSCode can't. 

var is native to Java since version 10 so Lombok var should not be used.

![278113210-58941a0b-9d02-4abb-a08c-63155c4d9528](https://github.com/thehyve/fairspace/assets/29271979/ca1f4c77-8752-4432-ad74-f690fc294a02)

![278113495-8b767614-bce5-400d-8591-4ef6478cfcd9](https://github.com/thehyve/fairspace/assets/29271979/b73bf1b4-3120-4827-aba1-2d503d231837)

