### PR TITLE
FAIRSPC-11:

### DIFF
--- a/projects/mercury/src/metadata/common/values/DateValue.js
+++ b/projects/mercury/src/metadata/common/values/DateValue.js
@@ -34,7 +34,7 @@ class DateValue extends React.Component {
         return (
             <LocalizationProvider dateAdapter={AdapterDateFns}>
                 <DatePicker
-                    format={DATE_FORMAT}
+                    inputFormat={DATE_FORMAT}
                     invalidDateMessage="Invalid date format"
                     value={this.state.value}
                     onChange={this.handleChange}


### PR DESCRIPTION
[FAIRSPC-11](https://thehyve.atlassian.net/browse/FAIRSPC-11)

1. fixed manual entering of dates in filter facets (`new Date(string)` converts two digits year XX to 1900+XX, like '02' -> '1902' )
2. improved input dates validation in filters (there were missed validation start date <= end date)
3. fixed date format (wrong property name was used)
4. fixed the month view of the DatePicker (wrong property name was used)

[FAIRSPC-11]: https://thehyve.atlassian.net/browse/FAIRSPC-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ