### PR TITLE
Update Jena and Milton

### DIFF
--- a/projects/mercury/src/routes/WorkspaceRoutes.js
+++ b/projects/mercury/src/routes/WorkspaceRoutes.js
@@ -16,7 +16,7 @@ import UserContext from "../users/UserContext";
 import UserRolesPage from "../users/UserRolesPage";
 import MetadataView from '../metadata/views/MetadataView';
 import BreadcrumbsContext from '../common/contexts/BreadcrumbsContext';
-import {ExternalStoragePage} from "../external-storage/ExternalStoragePage";
+import ExternalStoragePage from "../external-storage/ExternalStoragePage";
 import ExternalMetadataSourcesView from "../metadata/external-sources/ExternalMetadataSourceView";
 import {METADATA_VIEW_MENU_LABEL} from "../constants";
 

--- a/projects/saturn/build.gradle
+++ b/projects/saturn/build.gradle
@@ -1,9 +1,9 @@
 buildscript {
     ext {
-        jena_version = '4.3.2'
-        milton_version = '3.0.1.269'
+        jena_version = '4.10.0'
+        milton_version = '3.1.1.488' // Milton >= 4 is migrated to Jakarta EE 9, which is not compatible with Jena < 5 (no stable release of Jena 5 yet). To be updated when Jena 5 is released.
         mockitoVersion = '5.11.0'
-        jacksonVersion = '2.14.2' // check what version is used by Jena
+        jacksonVersion = '2.15.3' // check what version is used by Jena
         postgresqlVersion = '42.7.2'
     }
 }
@@ -51,7 +51,8 @@ dependencies {
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonVersion}"
     implementation "com.sparkjava:spark-core:2.9.4"
     implementation 'com.pivovarit:throwing-function:1.5.1'
-    implementation 'com.google.guava:guava:27.1-jre'
+    implementation 'com.google.guava:guava:33.0.0-jre'
+//    implementation 'jakarta.servlet:jakarta.servlet-api:6.0.0' // To be updated when Jena 5 is released.
     implementation('com.io-informatics.oss:jackson-jsonld:0.1.1') {
         exclude group: 'com.github.jsonld-java'
     }
@@ -63,9 +64,10 @@ dependencies {
 
     implementation 'org.keycloak:keycloak-jetty94-adapter:23.0.7'
     implementation 'org.keycloak:keycloak-admin-client:23.0.7'
+    implementation 'org.keycloak:keycloak-policy-enforcer:23.0.7'
 
     implementation "org.postgresql:postgresql:${postgresqlVersion}"
-    implementation "com.zaxxer:HikariCP:3.4.5"
+    implementation "com.zaxxer:HikariCP:5.1.0"
 
     runtimeOnly 'org.apache.logging.log4j:log4j-api:2.23.0'
     runtimeOnly 'org.apache.logging.log4j:log4j-core:2.23.0'

--- a/projects/saturn/src/main/java/io/fairspace/saturn/rdf/SaturnDatasetFactory.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/rdf/SaturnDatasetFactory.java
@@ -30,7 +30,7 @@ public class SaturnDatasetFactory {
         var restoreNeeded = isRestoreNeeded(config.datasetPath);
 
         // Create a TDB2 dataset graph
-        var dsg = connectCreate(Location.create(config.datasetPath.getAbsolutePath()), config.storeParams)
+        var dsg = connectCreate(Location.create(config.datasetPath.getAbsolutePath()), config.storeParams, null)
                 .getDatasetGraph();
 
         var txnLog = new LocalTransactionLog(config.transactionLogPath, new SparqlTransactionCodec());


### PR DESCRIPTION
Resolve [FAIRSPC-43](https://thehyve.atlassian.net/browse/FAIRSPC-43)

Fortunately no more issues with higher versions of Jena and Milton and no major changes needed (locally I tested most of metadata and file operations).

Only limitation on Milton upgrade to version >=4 is that in Milton 4 there was a migration from javax.servlet to jakarta.servlet. Currently we are blocked with such migration in Saturn by Jena, we need to wait for stable release of Jena version 5, where jakarta namespace is being used, but for now only rc was released. 

[FAIRSPC-43]: https://thehyve.atlassian.net/browse/FAIRSPC-43?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ