### PR TITLE
Remove code for special decoding of webdav response.

### DIFF
--- a/projects/mercury/src/file/FileAPI.js
+++ b/projects/mercury/src/file/FileAPI.js
@@ -2,14 +2,7 @@ import {createClient} from 'webdav';
 import qs from 'qs';
 import {compareBy, comparing} from '../common/utils/genericUtils';
 // eslint-disable-next-line import/no-cycle
-import {
-    decodeHTMLEntities,
-    encodePath,
-    generateUniqueFileName,
-    getFileName,
-    joinPaths,
-    joinPathsAvoidEmpty
-} from './fileUtils';
+import {encodePath, generateUniqueFileName, getFileName, joinPaths, joinPathsAvoidEmpty} from './fileUtils';
 import {handleHttpError} from '../common/utils/httpUtils';
 
 // Ensure that the client passes along the credentials
@@ -479,12 +472,6 @@ class FileAPI {
     mapToFile = fileObject => {
         const properties = {...fileObject, ...(fileObject.props || {})};
         delete properties.props;
-        Object.keys(properties).forEach(key => {
-            // The WebDAV client does not properly decode the XML response,
-            // so we need to do that here
-            const value = properties[key];
-            properties[key] = typeof value === 'string' ? decodeHTMLEntities(value) : value;
-        });
         return properties;
     };
 }

--- a/projects/mercury/src/file/fileUtils.js
+++ b/projects/mercury/src/file/fileUtils.js
@@ -137,12 +137,6 @@ export function generateUniqueFileName(fileName, usedNames = []) {
     return newName;
 }
 
-export const decodeHTMLEntities = (htmlSource: string) => {
-    const element = document.createElement('textarea');
-    element.innerHTML = htmlSource;
-    return element.textContent;
-};
-
 export const isUnsafeFileName = fileName => NON_SAFE_FILE_NAMES.includes(fileName);
 
 export const fileNameContainsInvalidCharacter = fileName =>


### PR DESCRIPTION
The `decodeHTMLEntities` seems not to be needed and it introduces vulnerability: "DOM text reinterpreted as HTML" -  CWE-79, CWE-116.

There is an issue with special characters in external storages, but this function doesn't fix the problem (reported in [FAIRSPC-62](https://thehyve.atlassian.net/browse/FAIRSPC-62)) 

[FAIRSPC-62]: https://thehyve.atlassian.net/browse/FAIRSPC-62?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ