### PR TITLE
Update fairspace-ingress.yaml to allow pathType override

### DIFF
--- a/charts/fairspace/templates/ingress/fairspace-ingress.yaml
+++ b/charts/fairspace/templates/ingress/fairspace-ingress.yaml
@@ -23,7 +23,7 @@ spec:
       http:
         paths:
           - path: /
-            pathType: ImplementationSpecific
+            pathType: {{ $ingress.pathType | default "ImplementationSpecific" }}
             backend:
               service:
                 name: {{ .Release.Name }}

--- a/charts/fairspace/values.yaml
+++ b/charts/fairspace/values.yaml
@@ -13,12 +13,15 @@ external:
     clientSecret:
 
 # Setup ingress for fairspace components
+# Change pathType to "Prefix" for ingress providers which do not default to prefix or wildcard
+#  matching for the "/" path, eg: AWS ALB
 fairspace:
   name: "fairspace"
   description: "Fairspace"
   ingress:
     enabled: true
     domain:
+    pathType: ImplementationSpecific
     annotations:
       pluto:
         kubernetes.io/ingress.class: nginx


### PR DESCRIPTION
The hardcoded ImplementationSpecific pathType will break the intended functionality for ingress providers which do not default to prefix matching, such as the AWS ALB, which defaults to exact matching.