### PR TITLE
Add resolvable URL query params filters, fix issues.

### DIFF
--- a/projects/mercury/src/constants.js
+++ b/projects/mercury/src/constants.js
@@ -22,6 +22,8 @@ export const DATE_FORMAT = 'dd-MM-yyyy';
 // The maximum number of items in a list in the right panel, for performance reasons.
 // If you change this, also change it in 'MetadataService.java'
 export const MAX_LIST_LENGTH = 100;
+// Max length of URL in the browser
+export const MAX_URL_LENGTH = 2000;
 
 // Metadata schemas
 export const SHACL_NS = 'http://www.w3.org/ns/shacl#';

--- a/projects/mercury/src/metadata/common/LinkedDataEntityForm.js
+++ b/projects/mercury/src/metadata/common/LinkedDataEntityForm.js
@@ -97,7 +97,7 @@ export const LinkedDataEntityForm = ({
                             labelFirst,
                             descriptionFirst,
                             systemPropertiesLast,
-                            compareBy(p => (typeof p.order === 'number' ? p.order : Number.MAX_SAFE_INTEGER)),
+                            compareBy(p => (Number.isNaN(Number(p.order)) ? Number.MAX_SAFE_INTEGER : Number(p.order))),
                             compareBy('label')
                         )
                     )

--- a/projects/mercury/src/metadata/common/values/ReferringValue.js
+++ b/projects/mercury/src/metadata/common/values/ReferringValue.js
@@ -34,7 +34,9 @@ export const ReferringValue = ({property, entry}) => {
         // External links should be represented by a direct link to the URI itself
         // Other iri entities should be opened in the metadata editor
         return property.isExternalLink ? (
-            <a href={entry.id}>{entry.id}</a>
+            <a href={entry.id} target="_blank" rel="noreferrer">
+                {entry.id}
+            </a>
         ) : (
             <LinkedDataLink uri={entry.id}>{displayValue}</LinkedDataLink>
         );

--- a/projects/mercury/src/metadata/common/values/__tests__/ReferringValue.js
+++ b/projects/mercury/src/metadata/common/values/__tests__/ReferringValue.js
@@ -18,7 +18,11 @@ describe('ReferringValue', () => {
                 property,
                 entry
             })
-        ).toEqual(<a href="https://thehyve.nl">https://thehyve.nl</a>);
+        ).toEqual(
+            <a rel="noreferrer" target="_blank" href="https://thehyve.nl">
+                https://thehyve.nl
+            </a>
+        );
     });
 
     it('should render a generic iri resource as link to editor', () => {

--- a/projects/mercury/src/metadata/views/MetadataView.styles.js
+++ b/projects/mercury/src/metadata/views/MetadataView.styles.js
@@ -29,9 +29,11 @@ const styles = theme => ({
     clearAllButtonContainer: {
         textAlign: 'end'
     },
-    clearAllButton: {
+    filterButtons: {
         color: theme.palette.primary.contrastText,
-        background: theme.palette.primary.main
+        background: theme.palette.primary.main,
+        marginLeft: 1,
+        marginBottom: 1
     },
     activeFilters: {
         marginBottom: 10

--- a/projects/mercury/src/metadata/views/MetadataViewActiveFacetFilters.js
+++ b/projects/mercury/src/metadata/views/MetadataViewActiveFacetFilters.js
@@ -64,7 +64,7 @@ export const MetadataViewActiveFacetFilters = (props: MetadataViewActiveFacetFil
             );
         }
         return filter.values.map(valueIri => {
-            const value = facet.values.find(val => val.value === valueIri);
+            const value = facet.values.find(val => val.value.toLowerCase() === valueIri.toLowerCase());
             return (
                 value && (
                     <Chip
@@ -95,7 +95,7 @@ export const MetadataViewActiveFacetFilters = (props: MetadataViewActiveFacetFil
                     ) {
                         return null;
                     }
-                    const facet = facets.find(f => f.name === filter.field);
+                    const facet = facets.find(f => f.name.toLowerCase() === filter.field.toLowerCase());
                     if (facet) {
                         return (
                             <Grid key={filter.field} item>

--- a/projects/mercury/src/metadata/views/MetadataViewContext.js
+++ b/projects/mercury/src/metadata/views/MetadataViewContext.js
@@ -11,7 +11,6 @@ const SESSION_STORAGE_METADATA_FILTERS_KEY = 'FAIRSPACE_METADATA_FILTERS';
 
 export const MetadataViewProvider = ({children, metadataViewAPI = MetadataViewAPI, sourceName = ''}) => {
     const {data = {}, error, loading, refresh} = useAsync(() => metadataViewAPI.getViews(), []);
-
     const [filters: MetadataViewFilter[], setFilters] = useStateWithSessionStorage(
         `${SESSION_STORAGE_METADATA_FILTERS_KEY}_${sourceName}`,
         []
@@ -23,11 +22,14 @@ export const MetadataViewProvider = ({children, metadataViewAPI = MetadataViewAP
 
     const clearAllFilters = () => {
         setFilters([]);
+        const queryParams = new URLSearchParams(window.location.search);
+        const viewParam = queryParams.get('view');
+        window.history.replaceState(null, '', `${window.location.pathname}?${viewParam ? `view=${viewParam}` : ''}`);
     };
 
     const updateFilters = (filterCandidates: MetadataViewFilter[]) => {
         setFilters([
-            ...filters.filter(f => !filterCandidates.some(u => u.field === f.field)),
+            ...filters.filter(f => !filterCandidates.some(u => u.field.toLowerCase() === f.field.toLowerCase())),
             ...filterCandidates.filter(
                 f =>
                     (f.values && f.values.length > 0) ||

--- a/projects/mercury/src/metadata/views/MetadataViewFacets.js
+++ b/projects/mercury/src/metadata/views/MetadataViewFacets.js
@@ -79,7 +79,9 @@ export const MetadataViewFacets = (props: MetadataViewFacetsProperties) => {
 
     const renderSingleFacet = (facet: MetadataViewFacet) => {
         const facetOptions = getFilterValues(facet.type, facet);
-        const activeFilter = [...filterCandidates, ...filters].find(filter => filter.field === facet.name);
+        const activeFilter = [...filterCandidates, ...filters].find(
+            filter => filter.field.toLowerCase() === facet.name.toLowerCase()
+        );
         let activeFilterValues = [];
         if (activeFilter) {
             activeFilterValues = getFilterValues(facet.type, activeFilter);

--- a/projects/mercury/src/metadata/views/MetadataViewTable.js
+++ b/projects/mercury/src/metadata/views/MetadataViewTable.js
@@ -1,15 +1,14 @@
-import React, {useCallback, useEffect} from 'react';
+import React, {useCallback} from 'react';
 import {Checkbox, Link, Table, TableBody, TableCell, TableHead, TableRow} from '@mui/material';
 import {Check, Close} from '@mui/icons-material';
 import makeStyles from '@mui/styles/makeStyles';
 import {Link as RouterLink} from 'react-router-dom';
-import qs from 'qs';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import type {MetadataViewColumn, MetadataViewData} from './MetadataViewAPI';
 import {TextualValueTypes} from './MetadataViewAPI';
 import type {MetadataViewEntity, MetadataViewEntityWithLinkedFiles} from './metadataViewUtils';
 import {RESOURCES_VIEW} from './metadataViewUtils';
-import {stringToBooleanValueOrNull, formatDate} from '../../common/utils/genericUtils';
+import {formatDate, stringToBooleanValueOrNull} from '../../common/utils/genericUtils';
 import type {Collection} from '../../collections/CollectionAPI';
 import {collectionAccessIcon} from '../../collections/collectionUtils';
 import {getPathFromIri, redirectLink} from '../../file/fileUtils';
@@ -52,12 +51,12 @@ const RESOURCE_TYPE_COLUMN = `${RESOURCES_VIEW}_type`;
 export const MetadataViewTable = (props: MetadataViewTableProperties) => {
     const {columns, visibleColumnNames, loading, data, toggleRow, selected, view, idColumn, history, collections} =
         props;
-    const classes = useStyles();
     const {textFiltersObject, setTextFiltersObject} = props;
+    const {checkboxes, setCheckboxState} = props;
+    const classes = useStyles();
     const visibleColumns = columns.filter(column => visibleColumnNames.includes(column.name));
     const dataLinkColumn = columns.find(c => c.type === 'dataLink');
     const isResourcesView = view === RESOURCES_VIEW;
-    const {checkboxes, setCheckboxState} = props;
 
     const isCustomResourceColumn = (column: MetadataViewColumn) =>
         isResourcesView && CUSTOM_RESOURCE_COLUMNS.includes(column.name) && column.type === 'Custom';
@@ -65,11 +64,6 @@ export const MetadataViewTable = (props: MetadataViewTableProperties) => {
     const getAccess = (iri: string) => {
         const col = collections.find(c => c.iri === iri || iri.startsWith(c.iri + '/'));
         return col ? col.access : 'None';
-    };
-
-    const getIdColumnFilterFromSearchParams = () => {
-        const idColumnName = idColumn.name.toLowerCase();
-        return qs.parse(window.location.search, {ignoreQueryPrefix: true})[idColumnName];
     };
 
     const getResourceType = (row: Map<string, any>) =>
@@ -82,15 +76,6 @@ export const MetadataViewTable = (props: MetadataViewTableProperties) => {
             toggleRow({label, iri, linkedFiles: linkedFiles || []});
         }
     };
-    useEffect(() => {
-        if (!textFiltersObject || !textFiltersObject.keys || !textFiltersObject.keys.includes(idColumn)) {
-            const idColumnTextFilter = getIdColumnFilterFromSearchParams();
-            if (idColumnTextFilter) {
-                setTextFiltersObject({...textFiltersObject, [idColumn.name]: idColumnTextFilter});
-            }
-        }
-        // eslint-disable-next-line
-    }, []);
 
     const initializeCheckboxes = useCallback(() => {
         if (idColumn && data && data.rows) {

--- a/projects/mercury/src/metadata/views/MetadataViewTableContainer.js
+++ b/projects/mercury/src/metadata/views/MetadataViewTableContainer.js
@@ -19,7 +19,7 @@ import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 import CheckBoxIcon from '@mui/icons-material/CheckBox';
 import GetAppIcon from '@mui/icons-material/GetApp';
 import FormGroup from '@mui/material/FormGroup';
-import useDeepCompareEffect from 'use-deep-compare-effect';
+import useDeepCompareEffect, {useDeepCompareEffectNoCheck} from 'use-deep-compare-effect';
 import {useTheme} from '@mui/material/styles';
 
 import type {MetadataViewColumn, MetadataViewFilter} from './MetadataViewAPI';
@@ -376,7 +376,7 @@ export const MetadataViewTableContainer = (props: MetadataViewTableContainerProp
         setPage(0);
     }, [filters]);
 
-    useDeepCompareEffect(() => {
+    useDeepCompareEffectNoCheck(() => {
         resetRowCheckboxes();
     }, [data]);
 

--- a/projects/saturn/src/main/java/io/fairspace/saturn/services/metadata/validation/UniqueLabelValidator.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/services/metadata/validation/UniqueLabelValidator.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Component;
 
 import io.fairspace.saturn.vocabulary.FS;
 
+import static org.apache.jena.rdf.model.ResourceFactory.createPlainLiteral;
+
 @Component
 public class UniqueLabelValidator implements MetadataRequestValidator {
     @Override
@@ -21,7 +23,7 @@ public class UniqueLabelValidator implements MetadataRequestValidator {
                     .filterDrop(res -> res.hasProperty(FS.dateDeleted))
                     .hasNext();
             if (conflictingResourceExists) {
-                violationHandler.onViolation("Duplicate label", resource, RDFS.label, null);
+                violationHandler.onViolation("Duplicate label", resource, RDFS.label, createPlainLiteral(label));
             }
         });
     }

--- a/projects/saturn/src/main/java/io/fairspace/saturn/services/metadata/validation/ValidationException.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/services/metadata/validation/ValidationException.java
@@ -1,6 +1,7 @@
 package io.fairspace.saturn.services.metadata.validation;
 
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -9,4 +10,13 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public class ValidationException extends RuntimeException {
     private final Set<Violation> violations;
+
+    @Override
+    public String getMessage() {
+        if (violations == null || violations.isEmpty()) {
+            return "Validation failed with no specific violations.";
+        }
+        return "Validation failed with the following violations: "
+                + violations.stream().map(Violation::toString).collect(Collectors.joining(", "));
+    }
 }

--- a/projects/saturn/src/main/java/io/fairspace/saturn/services/views/MaterializedViewService.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/services/views/MaterializedViewService.java
@@ -5,7 +5,6 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import javax.sql.DataSource;
 
 import lombok.extern.slf4j.Slf4j;
@@ -250,10 +249,8 @@ public class MaterializedViewService {
             if ("id".equalsIgnoreCase(attr)) {
                 continue;
             }
-            var isOfSetType = configuration
-                    .propertyTables
-                    .getOrDefault(joinView.view, Map.of())
-                    .containsKey(attr);
+            var propTable = configuration.propertyTables.get(joinView.view);
+            var isOfSetType = propTable != null && propTable.containsKey(attr);
             tableAliases.put(joinedTable + "_" + attr.toLowerCase(), isOfSetType ? "jt_" + (i + 1) : "jt_0");
         }
         for (int i = 0; i < joinView.include.size(); i++) {
@@ -292,10 +289,8 @@ public class MaterializedViewService {
 
         for (int i = 0; i < joinView.include.size(); i++) {
             var attr = joinView.include.get(i);
-            var isOfSetType = configuration
-                    .propertyTables
-                    .getOrDefault(joinView.view, Map.of())
-                    .containsKey(attr);
+            var propTable = configuration.propertyTables.get(joinView.view);
+            var isOfSetType = propTable != null && propTable.containsKey(attr);
             if (!isOfSetType) {
                 continue;
             }

--- a/projects/saturn/src/main/java/io/fairspace/saturn/services/views/ViewStoreClient.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/services/views/ViewStoreClient.java
@@ -10,8 +10,6 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -23,6 +21,7 @@ import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.util.LinkedCaseInsensitiveMap;
 
 import io.fairspace.saturn.config.properties.ViewsProperties;
 import io.fairspace.saturn.services.views.Table.ColumnDefinition;
@@ -34,14 +33,16 @@ import static io.fairspace.saturn.services.views.Table.valueColumn;
 public class ViewStoreClient implements AutoCloseable {
 
     public static class ViewStoreConfiguration {
-        final Map<String, ViewsProperties.View> viewConfig;
-        final Map<String, Table> viewTables = new HashMap<>();
-        final Map<String, Map<String, Table>> propertyTables = new HashMap<>();
-        final Map<String, Map<String, Table>> joinTables = new HashMap<>();
+        final LinkedCaseInsensitiveMap<ViewsProperties.View> viewConfig;
+        final LinkedCaseInsensitiveMap<Table> viewTables = new LinkedCaseInsensitiveMap<>();
+        final LinkedCaseInsensitiveMap<LinkedCaseInsensitiveMap<Table>> propertyTables =
+                new LinkedCaseInsensitiveMap<>();
+        final LinkedCaseInsensitiveMap<LinkedCaseInsensitiveMap<Table>> joinTables = new LinkedCaseInsensitiveMap<>();
 
         public ViewStoreConfiguration(ViewsProperties viewsProperties) {
-            viewConfig =
-                    viewsProperties.views.stream().collect(Collectors.toMap(view -> view.name, Function.identity()));
+            viewConfig = new LinkedCaseInsensitiveMap<>();
+            viewConfig.putAll(
+                    viewsProperties.views.stream().collect(Collectors.toMap(view -> view.name, Function.identity())));
         }
     }
 
@@ -272,7 +273,7 @@ public class ViewStoreClient implements AutoCloseable {
         tables.add(configuration.viewTables.get(view));
         tables.addAll(configuration
                 .propertyTables
-                .getOrDefault(view, Collections.emptyMap())
+                .getOrDefault(view, new LinkedCaseInsensitiveMap<>())
                 .values());
         var joins = configuration.viewConfig.get(view).join;
         if (joins != null) {

--- a/projects/saturn/src/main/java/io/fairspace/saturn/services/views/ViewStoreClientFactory.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/services/views/ViewStoreClientFactory.java
@@ -4,7 +4,6 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -19,6 +18,7 @@ import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedCaseInsensitiveMap;
 
 import io.fairspace.saturn.config.properties.ViewDatabaseProperties;
 import io.fairspace.saturn.config.properties.ViewsProperties;
@@ -252,7 +252,7 @@ public class ViewStoreClientFactory {
             var name = String.format("%s_%s", view.name.toLowerCase(), column.name.toLowerCase());
             var propertyTable = new Table(name, propertyTableColumns);
             createOrUpdateTable(propertyTable);
-            configuration.propertyTables.putIfAbsent(view.name, new HashMap<>());
+            configuration.propertyTables.putIfAbsent(view.name, new LinkedCaseInsensitiveMap<>());
             configuration.propertyTables.get(view.name).put(column.name, propertyTable);
         }
         if (view.join != null) {
@@ -260,9 +260,8 @@ public class ViewStoreClientFactory {
             for (ViewsProperties.View.JoinView join : view.join) {
                 var joinTable = getJoinTable(join, view);
                 createOrUpdateJoinTable(joinTable);
-                configuration.joinTables.putIfAbsent(view.name, new HashMap<>());
+                configuration.joinTables.putIfAbsent(view.name, new LinkedCaseInsensitiveMap<>());
                 configuration.joinTables.get(view.name).put(join.view, joinTable);
-                var joinView = configuration.viewConfig.get(join.view);
             }
         }
     }

--- a/projects/saturn/src/test/java/io/fairspace/saturn/services/views/JdbcQueryServiceTest.java
+++ b/projects/saturn/src/test/java/io/fairspace/saturn/services/views/JdbcQueryServiceTest.java
@@ -254,6 +254,16 @@ public class JdbcQueryServiceTest extends PostgresAwareTest {
     }
 
     @Test
+    public void retrieveSamplePageIsCaseInsensitive() {
+        var request = new ViewRequest();
+        request.setView("sample");
+        request.setPage(1);
+        request.setSize(10);
+        var page = sut.retrieveViewPage(request);
+        Assert.assertEquals(2, page.getRows().size());
+    }
+
+    @Test
     public void testRetrieveSamplePageAfterReindexing() {
         maintenanceService.recreateIndex();
         var request = new ViewRequest();
@@ -357,6 +367,29 @@ public class JdbcQueryServiceTest extends PostgresAwareTest {
     }
 
     @Test
+    public void retrieveSamplePageIncludeJoinIsCaseInsensitive() {
+        var request = new ViewRequest();
+        request.setView("sample");
+        request.setPage(1);
+        request.setSize(10);
+        request.setIncludeJoinedViews(true);
+        var page = sut.retrieveViewPage(request);
+        Assert.assertEquals(2, page.getRows().size());
+        var row1 = page.getRows().getFirst();
+        Assert.assertEquals(
+                "Sample A for subject 1",
+                row1.get("Sample").stream().findFirst().orElseThrow().label());
+        Assert.assertEquals(1, row1.get("Subject").size());
+        var row2 = page.getRows().get(1);
+        Assert.assertEquals(
+                "Sample B for subject 2",
+                row2.get("Sample").stream().findFirst().orElseThrow().label());
+        Assert.assertEquals(
+                Set.of("RNA-seq", "Whole genome sequencing"),
+                row2.get("Resource_analysisType").stream().map(ValueDto::label).collect(Collectors.toSet()));
+    }
+
+    @Test
     public void testRetrieveSamplePageIncludeJoinAfterReindexing() {
         maintenanceService.recreateIndex();
         var request = new ViewRequest();
@@ -385,6 +418,15 @@ public class JdbcQueryServiceTest extends PostgresAwareTest {
         selectRegularUser();
         var requestParams = new CountRequest();
         requestParams.setView("Sample");
+        var result = sut.count(requestParams);
+        assertEquals(2, result.count());
+    }
+
+    @Test
+    public void countSamplesIsCaseInsensitive() {
+        selectRegularUser();
+        var requestParams = new CountRequest();
+        requestParams.setView("sample");
         var result = sut.count(requestParams);
         assertEquals(2, result.count());
     }


### PR DESCRIPTION
Adds feature to enable redirection links to Fairspace with metadata prefiltering as a first step for enhancing external tools integration with Fairspace.

Fixes smaller issues, including right panel property ordering using `sh:order`, metadata validation error message improvements and changes to metadata query filters to be case insensitive.