### PR TITLE
Add cleanup of ThreadLocal for reusable threads from the pool.

### DIFF
--- a/projects/saturn/src/main/java/io/fairspace/saturn/auth/RequestContext.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/auth/RequestContext.java
@@ -101,4 +101,9 @@ public class RequestContext {
             return (String) claims.get(NAME);
         }
     }
+
+    public static void clear() {
+        currentRequest.remove();
+        currentUserUri.remove();
+    }
 }

--- a/projects/saturn/src/main/java/io/fairspace/saturn/auth/RequestContextCleanupFilter.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/auth/RequestContextCleanupFilter.java
@@ -1,0 +1,18 @@
+package io.fairspace.saturn.auth;
+
+import java.io.IOException;
+
+import jakarta.servlet.*;
+
+public class RequestContextCleanupFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        try {
+            chain.doFilter(request, response);
+        } finally {
+            RequestContext.clear();
+        }
+    }
+}

--- a/projects/saturn/src/main/java/io/fairspace/saturn/auth/SecurityConfig.java
+++ b/projects/saturn/src/main/java/io/fairspace/saturn/auth/SecurityConfig.java
@@ -1,6 +1,7 @@
 package io.fairspace.saturn.auth;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -35,5 +36,13 @@ public class SecurityConfig {
                 .cors(Customizer.withDefaults());
 
         return http.build();
+    }
+
+    @Bean
+    public FilterRegistrationBean<RequestContextCleanupFilter> threadLocalCleanupFilter() {
+        FilterRegistrationBean<RequestContextCleanupFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(new RequestContextCleanupFilter());
+        registrationBean.addUrlPatterns("/*");
+        return registrationBean;
     }
 }

--- a/projects/saturn/src/test/java/io/fairspace/saturn/auth/RequestContextTest.java
+++ b/projects/saturn/src/test/java/io/fairspace/saturn/auth/RequestContextTest.java
@@ -35,6 +35,7 @@ public class RequestContextTest {
     @Test
     public void getUserURI_shouldReturnNullWhenNoJwt() {
         SecurityContextHolder.clearContext();
+        RequestContext.clear();
         assertNull(RequestContext.getUserURI());
     }
 
@@ -49,6 +50,6 @@ public class RequestContextTest {
     public void getClaims_shouldReturnEmptyClaimsWhenNoJwt() {
         SecurityContextHolder.clearContext();
         RequestContext.SaturnClaims claims = RequestContext.getClaims();
-        assertTrue(claims.getSubject().isEmpty());
+        assertNull(claims.getSubject());
     }
 }

--- a/projects/saturn/src/test/java/io/fairspace/saturn/auth/RequestContextTest.java
+++ b/projects/saturn/src/test/java/io/fairspace/saturn/auth/RequestContextTest.java
@@ -1,0 +1,54 @@
+package io.fairspace.saturn.auth;
+
+import java.util.Optional;
+
+import org.apache.jena.graph.Node;
+import org.junit.Test;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import io.fairspace.saturn.TestUtils;
+
+import static org.junit.Assert.*;
+
+public class RequestContextTest {
+
+    @Test
+    public void getCurrentUserStringUri_shouldReturnUserUri() {
+        String userUri = "http://example.com/user";
+        RequestContext.setCurrentUserStringUri(userUri);
+        assertEquals(Optional.of(userUri), RequestContext.getCurrentUserStringUri());
+    }
+
+    @Test
+    public void getCurrentUserStringUri_shouldReturnEmptyWhenNoUriSet() {
+        RequestContext.clear();
+        assertEquals(Optional.empty(), RequestContext.getCurrentUserStringUri());
+    }
+
+    @Test
+    public void getUserURI_shouldReturnUserUriFromJwt() {
+        TestUtils.mockAuthentication("testUser");
+        Node userUri = RequestContext.getUserURI();
+        assertNotNull(userUri);
+    }
+
+    @Test
+    public void getUserURI_shouldReturnNullWhenNoJwt() {
+        SecurityContextHolder.clearContext();
+        assertNull(RequestContext.getUserURI());
+    }
+
+    @Test
+    public void getClaims_shouldReturnClaimsFromJwt() {
+        TestUtils.mockAuthentication("testUser");
+        RequestContext.SaturnClaims claims = RequestContext.getClaims();
+        assertEquals("testUser", claims.getSubject());
+    }
+
+    @Test
+    public void getClaims_shouldReturnEmptyClaimsWhenNoJwt() {
+        SecurityContextHolder.clearContext();
+        RequestContext.SaturnClaims claims = RequestContext.getClaims();
+        assertTrue(claims.getSubject().isEmpty());
+    }
+}

--- a/projects/saturn/src/test/java/io/fairspace/saturn/controller/BaseControllerTest.java
+++ b/projects/saturn/src/test/java/io/fairspace/saturn/controller/BaseControllerTest.java
@@ -5,9 +5,9 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import io.fairspace.saturn.auth.JwtAuthConverterProperties;
 import io.fairspace.saturn.services.IRIModule;
@@ -16,7 +16,7 @@ import io.fairspace.saturn.services.IRIModule;
 @Import(BaseControllerTest.CustomObjectMapperConfig.class)
 public class BaseControllerTest {
 
-    @MockBean
+    @MockitoBean
     private JwtAuthConverterProperties jwtAuthConverterProperties;
 
     @TestConfiguration

--- a/projects/saturn/src/test/java/io/fairspace/saturn/controller/FeaturesControllerTest.java
+++ b/projects/saturn/src/test/java/io/fairspace/saturn/controller/FeaturesControllerTest.java
@@ -5,8 +5,8 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import io.fairspace.saturn.config.enums.Feature;
@@ -23,7 +23,7 @@ class FeaturesControllerTest extends BaseControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private FeatureProperties featureProperties;
 
     @Test

--- a/projects/saturn/src/test/java/io/fairspace/saturn/controller/MaintenanceControllerTest.java
+++ b/projects/saturn/src/test/java/io/fairspace/saturn/controller/MaintenanceControllerTest.java
@@ -3,15 +3,13 @@ package io.fairspace.saturn.controller;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import io.fairspace.saturn.services.maintenance.MaintenanceService;
 
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -23,7 +21,7 @@ class MaintenanceControllerTest extends BaseControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private MaintenanceService maintenanceService;
 
     @Test

--- a/projects/saturn/src/test/java/io/fairspace/saturn/controller/MetadataControllerTest.java
+++ b/projects/saturn/src/test/java/io/fairspace/saturn/controller/MetadataControllerTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import io.fairspace.saturn.services.metadata.MetadataService;
@@ -16,13 +16,8 @@ import static io.fairspace.saturn.controller.enums.CustomMediaType.TEXT_TURTLE;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(MetadataController.class)
 public class MetadataControllerTest extends BaseControllerTest {
@@ -30,7 +25,7 @@ public class MetadataControllerTest extends BaseControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private MetadataService metadataService;
 
     @Test

--- a/projects/saturn/src/test/java/io/fairspace/saturn/controller/SearchControllerTest.java
+++ b/projects/saturn/src/test/java/io/fairspace/saturn/controller/SearchControllerTest.java
@@ -5,8 +5,8 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import io.fairspace.saturn.controller.dto.SearchResultDto;
@@ -28,10 +28,10 @@ class SearchControllerTest extends BaseControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private SearchService searchService;
 
-    @MockBean
+    @MockitoBean
     private FileSearchService fileSearchService;
 
     @Test

--- a/projects/saturn/src/test/java/io/fairspace/saturn/controller/UserControllerTest.java
+++ b/projects/saturn/src/test/java/io/fairspace/saturn/controller/UserControllerTest.java
@@ -5,8 +5,8 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import io.fairspace.saturn.services.users.User;
@@ -26,7 +26,7 @@ class UserControllerTest extends BaseControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private UserService service;
 
     @Test

--- a/projects/saturn/src/test/java/io/fairspace/saturn/controller/ViewControllerTest.java
+++ b/projects/saturn/src/test/java/io/fairspace/saturn/controller/ViewControllerTest.java
@@ -8,8 +8,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import io.fairspace.saturn.config.properties.ViewsProperties;
@@ -37,10 +37,10 @@ public class ViewControllerTest extends BaseControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private ViewService viewService;
 
-    @MockBean(name = "queryService")
+    @MockitoBean(name = "queryService")
     private QueryService queryService;
 
     @Autowired

--- a/projects/saturn/src/test/java/io/fairspace/saturn/controller/WorkspaceControllerTest.java
+++ b/projects/saturn/src/test/java/io/fairspace/saturn/controller/WorkspaceControllerTest.java
@@ -10,8 +10,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import io.fairspace.saturn.services.workspaces.Workspace;
@@ -36,7 +36,7 @@ class WorkspaceControllerTest extends BaseControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private WorkspaceService workspaceService;
 
     @Test

--- a/projects/saturn/src/test/java/io/fairspace/saturn/controller/exception/GlobalExceptionHandlerTest.java
+++ b/projects/saturn/src/test/java/io/fairspace/saturn/controller/exception/GlobalExceptionHandlerTest.java
@@ -8,9 +8,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import io.fairspace.saturn.controller.BaseControllerTest;
@@ -29,7 +29,7 @@ public class GlobalExceptionHandlerTest extends BaseControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private TestController.TestInnerClass testInnerClass;
 
     @Test


### PR DESCRIPTION
 ThreadLocal variable is used in Saturn RequestContext to store user IRI within a thread.

When using thread pools the threads are reused, so the user IRI used previously for a thread was preserved and was reused for a different request and often different user, causing invalid request user being handled. 

This PR adds ThreadLocal variables cleanup before each new request using request filters.

See: https://www.baeldung.com/java-threadlocal#threadlocalsand-thread-pools

